### PR TITLE
Seed stacking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,3 @@
+master:
+  - obsplus.waveforms
+    * added stack_seed and unstack_seed methods to obsplus data array accessors

--- a/obsplus/waveforms/xarray/__init__.py
+++ b/obsplus/waveforms/xarray/__init__.py
@@ -4,7 +4,7 @@ Functionality for working with Xarray for seismology data.
 
 from obsplus.waveforms.xarray.accessor import ops_method, OPS_METHODS
 
-from obsplus.waveforms.xarray.utils import keep_attrs, _add_level
+from obsplus.waveforms.xarray.utils import keep_attrs, _add_level, get_nslc_df
 from obsplus.waveforms.xarray.io import netcdf2array
 
 

--- a/obsplus/waveforms/xarray/utils.py
+++ b/obsplus/waveforms/xarray/utils.py
@@ -177,18 +177,47 @@ def stack_seed(dar: xr.DataArray, level) -> xr.DataArray:
     level
         The seed-level (network, station, location or channel).
     """
+    dar = dar.copy()  # changes some things in place, make a copy
     # This is super ugly, and much harder than it should be.
     # get dataframe of seed levels
     assert level in NSLC
     df = get_nslc_df(dar)
     # create multi-index and swap out old seed_id for multi-level
-    ind = pd.MultiIndex.from_arrays((df[level].values, df.index.values),
-                                    names=(level, 'sid'))
+    ind = pd.MultiIndex.from_arrays(
+        (df[level].values, df.index.values), names=(level, "sid")
+    )
     dar.seed_id.values = ind
-    # unstack, then stack ids together and return
-    out = dar.unstack('seed_id')
-    out = out.stack(ids=('sid', 'stream_id')).transpose('ids', 'network', 'time')
-    return out
+    # unstack, drop nans, then stack ids together
+    out = dar.unstack("seed_id").rename({"sid": "seed_id"})
+    out = out.stack(ids=("seed_id", "stream_id"))
+    return out.dropna(dim="ids", how="all").transpose("ids", level, "time")
+
+
+@ops_method("unstack_seed")
+def unstack_seed(dar: xr.DataArray) -> xr.DataArray:
+    """
+    Unstack the DataArray stacked on a seed level.
+
+    The DataArray should have been created with the functon:
+    `~:func:obsplus.waveforms.xarray.utils.stack_seed`
+
+    Parameters
+    ----------
+    dar
+        An obsplus data array
+    """
+    # This is also super ugly, and much harder than it should be.
+    # find level that should be squished
+    level = set(NSLC) & set(dar.dims)
+    if len(level) != 1:
+        msg = "could not determine how to unstack data array based on seed level"
+        raise ValueError(msg)
+    level = list(level)[0]
+    # stack seed_id with level, remove multi-index
+    stack = ("seed_id", level)
+    dar1 = dar.unstack().stack(sid=stack).dropna(dim="sid", how="all")
+    dar1.sid.values = [x[0] for x in dar1.sid.values]
+    return dar1.rename({"sid": "seed_id"}).transpose(*DIMS)
 
 
 @ops_method("sel_sid")

--- a/tests/test_waveforms/test_xarray_stream.py
+++ b/tests/test_waveforms/test_xarray_stream.py
@@ -1200,3 +1200,21 @@ class Test2Netcdf:
         inv1 = default_array_more.attrs["stations"]
         inv2 = output_dar.attrs["stations"]
         assert inv1 == inv2
+
+
+class TestSeedStacking:
+    """ Tests for stacking waveform arrays by seed levels """
+
+    def test_all_level_stacks(self, crandall_data_array):
+        """
+        Test stacking the data array on all supported levels, and that
+        it can be unstacked.
+        """
+        # get a dataframe which splits network, station, location, and chan
+        seed_df = get_nslc_df(crandall_data_array)
+        # iterate each level and stack, then unstack
+        for level in seed_df.columns:
+            dar1 = crandall_data_array.copy()
+            dar2 = dar1.ops.stack_seed(level)
+            assert len(dar2[level]) == len(seed_df[level].unique())
+

--- a/tests/test_waveforms/test_xarray_stream.py
+++ b/tests/test_waveforms/test_xarray_stream.py
@@ -1217,4 +1217,15 @@ class TestSeedStacking:
             dar1 = crandall_data_array.copy()
             dar2 = dar1.ops.stack_seed(level)
             assert len(dar2[level]) == len(seed_df[level].unique())
+            assert (~dar1.isnull()).sum() == (~dar2.isnull()).sum()
+            # unstack, ensure dataarrays are equal and such
+            dar3 = dar2.ops.unstack_seed()
+            assert dar1.shape == dar3.shape
+            assert dar1.dims == dar3.dims
+            # all elements should be equal or null
+            assert ((dar1.values == dar3.values) | dar3.isnull().values).all()
 
+    def test_unstack_not_stacked_dar_rasies(self, default_array):
+        """ unstacking a data array that has not been stacked should raise """
+        with pytest.raises(ValueError):
+            default_array.ops.unstack_seed()


### PR DESCRIPTION
Adds an ObsPlus method for stacking `DataArray`s by seed levels (eg network, station, location, channel). Useful, for example, to shape data for input to vectorized functions. 

works like this:
```python
import obsplus
# create example data array
ds = obsplus.load_dataset('crandall')
st_dict = ds.get_fectcher.get_event_waveforms(10, 50)
dar  = obsplus.obspy_to_array_dict(st_dict)[40]
# stack by channels
dar_channels = dar.ops.stack_seed('channel')
```
Now the `dar_channels` has 3 dims. 1) multi-index of (stream_id, seed_id), 2) channels, 3) time.