### PR TITLE
fill missing origins

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
 master:
   - obsplus.waveforms
-    * added stack_seed and unstack_seed methods to obsplus data array accessors
+    * added stack_seed and unstack_seed methods to obsplus data array
+      accessors.
+  - obsplus.events
+    * added utility function to create origins based on first hit station if
+      an event has only picks.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest<4.0
 pytest-cov
 coveralls
 black


### PR DESCRIPTION
This PR adds  a function to events/utils that will create dummy origins based on the time of the first pick and location of the first hit station. Depth can be manually specified. This is potentially useful for codes that need a rough starting location.