### PR TITLE
pass times to obspy read functions and get_nslc_series

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ master:
   - obsplus.waveforms
     * added stack_seed and unstack_seed methods to obsplus data array
       accessors.
+    * speed up wavebank reads of file segments by passing start/end times
+      to underlying obspy functions.
   - obsplus.events
     * added utility function to create origins based on first hit station if
       an event has only picks.

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -42,6 +42,7 @@ from obsplus.utils import (
     to_timestamp,
     get_progressbar,
     thread_lock_function,
+    get_nslc_series,
 )
 
 # from obsplus.interfaces import WaveformClient
@@ -645,15 +646,7 @@ class WaveBank(_Bank):
                 stt += st
         # filter out any traces not in index (this can happen when files hold
         # multiple traces).
-        nslc = set(
-            index.network
-            + "."
-            + index.station
-            + "."
-            + index.location
-            + "."
-            + index.channel
-        )
+        nslc = set(get_nslc_series(index))
         stt.traces = [x for x in stt if x.id in nslc]
         # trim, merge, attach response
         self._polish_stream(stt, starttime, endtime, attach_response)

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -635,7 +635,12 @@ class WaveBank(_Bank):
         files: pd.Series = (self.bank_path + index.path).unique()
         # iterate the files to read and try to load into waveforms
         stt = obspy.Stream()
-        for st in (_try_read_stream(x, format=self.format) for x in files):
+        kwargs = dict(
+            format=self.format,
+            starttime=obspy.UTCDateTime(starttime) if starttime else None,
+            endtime=obspy.UTCDateTime(endtime) if endtime else None,
+        )
+        for st in (_try_read_stream(x, **kwargs) for x in files):
             if st is not None and len(st):
                 stt += st
         # filter out any traces not in index (this can happen when files hold

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -25,7 +25,7 @@ from obspy.io.mseed.core import _read_mseed as mread
 from obspy.io.quakeml.core import _read_quakeml
 from progressbar import ProgressBar
 
-from obsplus.constants import event_time_type
+from obsplus.constants import event_time_type, NSLC
 
 BASIC_NON_SEQUENCE_TYPE = (int, float, str, bool, type(None))
 # make a dict of functions for reading waveforms
@@ -578,3 +578,22 @@ def compose_docstring(**kwargs):
         return func
 
     return _wrap
+
+
+def get_nslc_series(df: pd.DataFrame) -> pd.Series:
+    """
+    Create a series of seed_ids from a dataframe with nslc columns.
+
+    Parameters
+    ----------
+    df
+        Any Dataframe that has str columns named:
+            network, station, location, channel
+
+    Returns
+    -------
+    A series of concatenated nslc codes.
+    """
+    assert set(NSLC).issubset(df.columns), f"dataframe must have {NSLC} in columns"
+    net, sta, loc, chan = [df[x].fillna("").astype(str) for x in NSLC]
+    return net + "." + sta + "." + loc + "." + chan

--- a/profiling/wavebank_file_segments.ipynb
+++ b/profiling/wavebank_file_segments.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Profile file segement read\n",
+    "Profile reading file segments from a large continuous bank.\n",
+    "Use the Kemmerer dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import obsplus\n",
+    "import obspy\n",
+    "\n",
+    "# load dataset and bank index/inv\n",
+    "ds = obsplus.load_dataset('kemmerer')\n",
+    "bank = ds.waveform_client\n",
+    "index = bank.read_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get start/stop of continuous archive\n",
+    "t1 = obspy.UTCDateTime(index.starttime.min())\n",
+    "t2 = obspy.UTCDateTime(index.endtime.max())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create requests for pulling a few seconds of data every hour\n",
+    "time = t1\n",
+    "requests = []\n",
+    "while time < t2:\n",
+    "    requests.append(('*', '*', '*', '*', time + 15, time + 30))\n",
+    "    time += 3600"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit \n",
+    "[bank.get_waveforms(*x) for x in requests]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "for st in bank.yield_waveforms(starttime=t1, endtime=t2, duration=3600, overlap=10):\n",
+    "    pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR speeds up reading segments of waveform files slightly by passing the `starttime` and `endtime` parameters to the underlying obspy functions from `WaveBank` internals. It also adds a convenience method for getting nslc columns from a dataframe with the appropriate columns.  