### PR TITLE
Supress progress bar update errors

### DIFF
--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -6,6 +6,7 @@ import os
 import re
 import time
 from collections import defaultdict
+from contextlib import suppress
 from functools import partial, lru_cache, reduce
 from itertools import chain
 from operator import add
@@ -202,8 +203,8 @@ class WaveBank(_Bank):
             updates.append(_summarize_wave_file(fi, format=self.format))
             # if more files are added during update this can raise
             if bar is not None:
-                # with suppress(Exception):
-                bar.update(num)  # ignore; progress bar isn't too important
+                with suppress(Exception):
+                    bar.update(num)  # ignore; progress bar isn't too important
         getattr(bar, "finish", lambda: None)()  # call finish if applicable
         if len(updates):  # flatten list and make df
             self._write_update(list(chain.from_iterable(updates)))

--- a/scripts/pre-commit.py
+++ b/scripts/pre-commit.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Pre-commit hook for ensuring files have been black formatted.
 """

--- a/scripts/publish_new_version.py
+++ b/scripts/publish_new_version.py
@@ -7,5 +7,5 @@ from subprocess import run
 
 if __name__ == "__main__":
     base = Path(__file__).parent.parent
-    run('python setup.py sdist bdist_wheel', shell=True, cwd=base)
-    run('twine upload dist/*', shell=True, cwd=base)
+    run("python setup.py sdist bdist_wheel", shell=True, cwd=base)
+    run("twine upload dist/*", shell=True, cwd=base)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,8 +224,13 @@ class TestMisc:
         """ ensure print doesn't propagate to std out when suppressed. """
         with obsplus.utils.no_std_out():
             print("whisper")
-        # nothing should have made it to stdout to get captured
-        assert not capsys.readouterr().out
+        # nothing should have made it to stdout to get captured. The
+        # output shape seems to be dependent on pytest version (or something).
+        capout = capsys.readouterr()
+        if isinstance(capout, tuple):
+            assert [not x for x in capout]
+        else:
+            assert not capout.out
 
     def test_to_timestamp(self):
         """ ensure things are properly converted to timestamps. """


### PR DESCRIPTION
Simply make sure the progress bar can't mess up the indexing of `WaveBank`
Also fixes a small pre-commit hook issue.