### PR TITLE
Ensure meta table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,8 @@ obsplus/datasets/**/events
 obsplus/datasets/**/.index
 obsplus/datasets/**/readme.txt
 obsplus/**/*.mseed
-docs/profiling/**/*.mseed
+profiling/**/*.mseed
+
 
 # shelve stuff
 *.dat

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -120,7 +120,8 @@ class WaveBank(_Bank):
     buffer = 10.111  # the time before and after the desired times to pull
 
     # dict defining lengths of str columns (after seed spec)
-    min_itemsize = {"path": 79, "station": 5, "network": 2, "location": 2, "channel": 3}
+    # Note: Empty strings get their dtypes caste as S8, which means 8 is the min
+    min_itemsize = {"path": 79, "station": 8, "network": 8, "location": 8, "channel": 8}
 
     # ----------------------------- setup stuff
 

--- a/profiling/profile_wavebank.ipynb
+++ b/profiling/profile_wavebank.ipynb
@@ -1,12 +1,21 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Profile wavebank indexing\n",
+    "This notebook is intended to help profile the "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import shutil\n",
+    "import tempfile\n",
     "from pathlib import Path\n",
     "\n",
     "import obspy\n",
@@ -15,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,19 +70,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "604 ms ± 6.09 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit index_update()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# shutil.rmtree(str(test_dir))"
+   ]
   }
  ],
  "metadata": {
@@ -92,7 +111,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR reworks `WaveBank` slightly to ensure the metatable exists, and changes the min str column lengths to 8.

In a large archive we use at NIOSH there were issues with the metatable not being written after indexing, and empty location codes  getting cast numpy character arrays with S8 dtypes. Since S8 is larger than the previous min of S2 an exception was raised on updates. This seems to have fixed both issues.