### PR TITLE
remove pytest namespace usage in waveform tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,7 @@ def collect_catalogs():
 
 
 cat_dict = collect_catalogs()
+waveform_cache_obj = ObspyCache('waveforms', obspy.read)
 
 
 # -------------------- collection of test cases
@@ -284,21 +285,45 @@ def bingham_bank_path(tmpdir_factory):
     return str(tmpdir)
 
 
+@pytest.fixture(scope='class', params=waveform_cache_obj.keys)
+def waveform_cache_stream(request):
+    """
+    Return the each stream in the cache
+    """
+    return waveform_cache_obj[request.param]
+
+@pytest.fixture(scope='class')
+def waveform_cache_trace(waveform_cache_stream):
+    """
+    Return the first trace of each test stream
+    """
+    return waveform_cache_stream[0]
+
+
+@pytest.fixture(scope='session')
+def waveform_cache():
+    """
+    Return the waveform cache object for tests to select which waveform
+    should be used by name.
+    """
+    return waveform_cache_obj
+
+
 # --------------- add things to the pytest namespace
 
 
-def pytest_namespace():
-    """ add the expected files to the py.test namespace """
-    odict = {
-        "test_data_path": TEST_DATA_PATH,
-        "test_path": TEST_PATH,
-        "package_path": PKG_PATH,
-        "data_path": TEST_DATA_PATH,
-        "events": cat_dict,
-        "append_func_name": append_func_name,
-        "waveforms": ObspyCache("waveforms", obspy.read),
-    }
-    return odict
+# def pytest_namespace():
+#     """ add the expected files to the py.test namespace """
+#     odict = {
+#         "test_data_path": TEST_DATA_PATH,
+#         "test_path": TEST_PATH,
+#         "package_path": PKG_PATH,
+#         "data_path": TEST_DATA_PATH,
+#         "events": cat_dict,
+#         "append_func_name": append_func_name,
+#         "waveforms": ObspyCache("waveforms", obspy.read),
+#     }
+#     return odict
 
 
 # -------------- configure test runner

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest<4.0
+pytest
 pytest-cov
 coveralls
 black

--- a/tests/test_bank/test_bank_utils.py
+++ b/tests/test_bank/test_bank_utils.py
@@ -44,9 +44,9 @@ class TestStreamPathStructure:
         return request.param
 
     @pytest.fixture(scope="class")
-    def output(self, struct_string, trace):
+    def output(self, struct_string, waveform_cache_first_trace):
         """ init a bank_structure class from the structure strings """
-        return _summarize_trace(trace, path_struct=struct_string)
+        return _summarize_trace(waveform_cache_first_trace, path_struct=struct_string)
 
     # general tests
 

--- a/tests/test_bank/test_bank_utils.py
+++ b/tests/test_bank/test_bank_utils.py
@@ -44,9 +44,9 @@ class TestStreamPathStructure:
         return request.param
 
     @pytest.fixture(scope="class")
-    def output(self, struct_string, waveform_cache_first_trace):
+    def output(self, struct_string, waveform_cache_trace):
         """ init a bank_structure class from the structure strings """
-        return _summarize_trace(waveform_cache_first_trace, path_struct=struct_string)
+        return _summarize_trace(waveform_cache_trace, path_struct=struct_string)
 
     # general tests
 

--- a/tests/test_events/test_catalog_utils.py
+++ b/tests/test_events/test_catalog_utils.py
@@ -28,29 +28,29 @@ CAT = obspy.read_events()
 # -------------------------- helper functions ----------------------- #
 
 
-def extract_merge_catalogs(merge_directory):
-    """ given a directory with two qmls, read in the qmls and return """
-    files = glob.glob(join(merge_directory, "*"))
-    cat_path1 = [x for x in files if x.endswith("1.xml")]
-    cat_path2 = [x for x in files if x.endswith("2.xml")]
-    cat1 = obspy.read_events(cat_path1[0])
-    cat2 = obspy.read_events(cat_path2[0])
-    validate(cat1)
-    validate(cat2)
-    return cat1, cat2
+# def extract_merge_catalogs(merge_directory):
+#     """ given a directory with two qmls, read in the qmls and return """
+#     files = glob.glob(join(merge_directory, "*"))
+#     cat_path1 = [x for x in files if x.endswith("1.xml")]
+#     cat_path2 = [x for x in files if x.endswith("2.xml")]
+#     cat1 = obspy.read_events(cat_path1[0])
+#     cat2 = obspy.read_events(cat_path2[0])
+#     validate(cat1)
+#     validate(cat2)
+#     return cat1, cat2
 
 
 # -------------------------- Module Fixtures
 
 
-@pytest.fixture(scope="class")
-def ms_catalog():
-    """ return a events of microseismic events """
-    cat = obspy.Catalog()
-    path = Path(pytest.test_data_path) / "qml_files"
-    for qml_path in path.rglob("*.xml"):
-        cat += obspy.read_events(str(qml_path))
-    return cat
+# @pytest.fixture(scope="class")
+# def ms_catalog():
+#     """ return a events of microseismic events """
+#     cat = obspy.Catalog()
+#     path = Path(pytest.test_data_path) / "qml_files"
+#     for qml_path in path.rglob("*.xml"):
+#         cat += obspy.read_events(str(qml_path))
+#     return cat
 
 
 # -------------------------------- tests ------------------------------- #
@@ -68,8 +68,8 @@ class TestDuplicateEvent:
         return duplicate_events(catalog)
 
     @pytest.fixture
-    def duplicated_big_catalog(self):
-        return obsplus.duplicate_events(pytest.cat6)
+    def duplicated_big_catalog(self, catalog_cache):
+        return obsplus.duplicate_events(catalog_cache["cat6"])
 
     def test_return_type(self, duplicated_catalog):
         """ ensure a events was returned """
@@ -101,12 +101,12 @@ class TestDuplicateEvent:
         """ ensure the duplicated events is valid """
         obsplus.validate_catalog(duplicated_big_catalog)
 
-    def test_interconnected_rids(self):
+    def test_interconnected_rids(self, catalog_cache):
         """ Tests for ensuring resource IDs are changed to point to new
         objects. This can get messed up when there are many objects
         that point to resource ids of other objects. EG picks/amplitudes.
         """
-        cat = duplicate_events(pytest.events.interconnected)
+        cat = duplicate_events(catalog_cache["interconnected"])
         # create a dict of pick ids and others that refer to picks
         pids = {str(x.resource_id): x for x in cat[0].picks}
         assert len(cat[0].origins) == 1, "there should be one origin"

--- a/tests/test_events/test_merge.py
+++ b/tests/test_events/test_merge.py
@@ -16,8 +16,6 @@ CAT = obspy.read_events()
 ORIGINS = [ori for eve in CAT for ori in eve.origins]
 MAGNITUDES = [mag for eve in CAT for mag in eve.magnitudes]
 ALLSORTS = ORIGINS + MAGNITUDES
-QMLS2MERGE = glob(join(pytest.test_data_path, "qml2merge", "*"))
-BASICMERGE = [x for x in QMLS2MERGE if x.endswith("2017-01-06T16-15-14")][0]
 
 
 # -------------------------- helper functions ----------------------- #
@@ -38,22 +36,16 @@ def extract_merge_catalogs(merge_directory):
 # --------------------------- module fixtures ----------------------- #
 
 
-@pytest.fixture(scope="class", params=QMLS2MERGE)
-def merge_catalogs(request):
+@pytest.fixture(scope="function")
+def merge_catalogs_function(qml_to_merge_paths):
     """ return a pair of catalogs for merge testing"""
-    return extract_merge_catalogs(request.param)
-
-
-@pytest.fixture(scope="function", params=QMLS2MERGE)
-def merge_catalogs_function(request):
-    """ return a pair of catalogs for merge testing"""
-    return extract_merge_catalogs(request.param)
+    return extract_merge_catalogs(qml_to_merge_paths)
 
 
 @pytest.fixture(scope="class")
-def merge_catalog_basic():
+def merge_catalog_basic(qml_to_merge_basic):
     """ return just the basic events used to test merging"""
-    return extract_merge_catalogs(BASICMERGE)
+    return extract_merge_catalogs(qml_to_merge_basic)
 
 
 # ------------------------------- tests ------------------------------ #
@@ -99,20 +91,20 @@ class TestMergePicks:
         return cat1, cat2
 
     @pytest.fixture()
-    def merge_catalogs_delete_pick(self):
+    def merge_catalogs_delete_pick(self, qml_to_merge_basic):
         """ delete a pick and amplitude from the new cat_name, merge
          with old """
 
-        cat1, cat2 = extract_merge_catalogs(BASICMERGE)
+        cat1, cat2 = extract_merge_catalogs(qml_to_merge_basic)
         cat2[0].picks.pop(0)
         cat2[0].amplitudes.pop(0)
         merge_events(cat1[0], cat2[0])
         return cat1, cat2
 
     @pytest.fixture()
-    def merge_catalogs_add_pick(self):
+    def merge_catalogs_add_pick(self, qml_to_merge_basic):
         """ add a pick and amplitude to the new cat_name, merge with old """
-        cat1, cat2 = extract_merge_catalogs(BASICMERGE)
+        cat1, cat2 = extract_merge_catalogs(qml_to_merge_basic)
         # add new pick
         pick1 = cat2[0].picks[0]
         time = obspy.UTCDateTime.now()
@@ -127,10 +119,10 @@ class TestMergePicks:
         return cat1, cat2
 
     @pytest.fixture()
-    def merge_catalogs_add_bad_amplitude(self):
+    def merge_catalogs_add_bad_amplitude(self, qml_to_merge_basic):
         """ add an amplitude that has no pick reference. It should not get
          merged into the events """
-        cat1, cat2 = extract_merge_catalogs(BASICMERGE)
+        cat1, cat2 = extract_merge_catalogs(qml_to_merge_basic)
         # add new amplitude
         amp = obspy.core.event.Amplitude()
         cat2[0].amplitudes.append(amp)

--- a/tests/test_events/test_pd_catalog.py
+++ b/tests/test_events/test_pd_catalog.py
@@ -17,9 +17,21 @@ from obsplus.constants import EVENT_COLUMNS, PICK_COLUMNS
 from obsplus.datasets.dataloader import base_path
 from obsplus.utils import get_preferred, getattrs
 
+
 # ---------------- helper functions
 
-append_func_name = pytest.append_func_name
+
+def append_func_name(list_obj):
+    """ decorator to append a function name to list_obj """
+
+    def wrap(func):
+        list_obj.append(func.__name__)
+        return func
+
+    return wrap
+
+
+# --------------- tests
 
 
 class TestCat2Df:
@@ -259,11 +271,9 @@ class TestReadPhasePicks:
     cat_name = "2016-04-13T23-51-13.xml"
 
     @pytest.fixture(scope="class")
-    def tcat(self):
+    def tcat(self, catalog_cache):
         """ retad in a events for testing """
-        path = join(pytest.test_data_path, "test_catalogs", self.cat_name)
-        assert os.path.exists(path)
-        return obspy.read_events(path)
+        return catalog_cache[self.cat_name]
 
     @pytest.fixture(scope="class")
     @append_func_name(fixtures)

--- a/tests/test_events/test_validate.py
+++ b/tests/test_events/test_validate.py
@@ -1,22 +1,21 @@
 from os.path import join
 
-import obsplus
-import obsplus.events.validate
 import obspy
 import pytest
-from obsplus import validate_catalog
 from obspy.core.event import ResourceIdentifier
 
-CAT1_PATH = join(pytest.test_data_path, "qml_files", "2017-01-16T01-15-13-8a42f.xml")
+import obsplus
+import obsplus.events.validate
+from obsplus import validate_catalog
 
 
 # ----------------- module level fixtures
 
 
 @pytest.fixture(scope="function")
-def cat1():
+def cat1(event_cache):
     """ return a copy of events 1"""
-    cat = obspy.read_events(CAT1_PATH)
+    cat = event_cache["2017-01-16T01-15-13-8a42f.xml"].copy()
     validate_catalog(cat)
     cat[0].focal_mechanisms.append(obspy.core.event.FocalMechanism())
     return cat

--- a/tests/test_structures/test_fetcher.py
+++ b/tests/test_structures/test_fetcher.py
@@ -20,9 +20,18 @@ from obsplus.utils import make_time_chunks, get_reference_time
 
 WAVEFETCHERS = []
 
+
 # ----------------------------- helper functions
 
-append_func_name = pytest.append_func_name
+
+def append_func_name(list_obj):
+    """ decorator to append a function name to list_obj """
+
+    def wrap(func):
+        list_obj.append(func.__name__)
+        return func
+
+    return wrap
 
 
 def trim_kem_events(fetcher: Fetcher):
@@ -755,7 +764,6 @@ class TestGetEventData:
 
 
 class TestGetContinuousData:
-
     t1 = obspy.UTCDateTime("2009-04-01").timestamp
     t2 = obspy.UTCDateTime("2009-04-01T03-00-00").timestamp
     duration = 1800

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
-""" tests for wavebank utilities """
+""" tests for various utility functions """
 import textwrap
-import itertools
 from pathlib import Path
 
 import obspy
@@ -10,10 +9,18 @@ from obspy import UTCDateTime
 from obspy.core.event import Catalog, Event, Origin
 
 import obsplus
-from obsplus.utils import compose_docstring, yield_obj_parent_attr
 from obsplus.constants import NSLC, NULL_NSLC_CODES
+from obsplus.utils import compose_docstring, yield_obj_parent_attr
 
-append_func_name = pytest.append_func_name
+
+def append_func_name(list_obj):
+    """ decorator to append a function name to list_obj """
+
+    def wrap(func):
+        list_obj.append(func.__name__)
+        return func
+
+    return wrap
 
 
 # ------------------------- module level fixtures

--- a/tests/test_waveforms/conftest.py
+++ b/tests/test_waveforms/conftest.py
@@ -44,10 +44,10 @@ def _change_stats(st, stat_attr, new_values):
 
 
 @pytest.fixture(scope="class")
-def basic_stream_with_gap():
+def basic_stream_with_gap(waveform_cache):
     """ return a waveforms with a 2 second gap in center, return combined
     waveforms with gaps, first chunk, second chunk """
-    st = pytest.waveforms["default"]
+    st = waveform_cache["default"]
     st1 = st.copy()
     st2 = st.copy()
     t1 = st[0].stats.starttime
@@ -70,7 +70,7 @@ def basic_stream_with_gap():
 @pytest.fixture(scope="class")
 def disjointed_stream():
     """ return a waveforms that has parts with no overlaps """
-    st = pytest.waveforms["default"]
+    st = obspy.read()
     st[0].stats.starttime += 3600
     return st
 
@@ -78,15 +78,15 @@ def disjointed_stream():
 @pytest.fixture(scope="class")
 def default_array():
     """ the basic waveforms turned into an array """
-    st = pytest.waveforms["default"]
+    st = obspy.read()
     return obspy_to_array(st)
 
 
 @pytest.fixture(scope="class")
-def stream_dict():
+def stream_dict(waveform_cache):
     """ return a dictionary of streams """
     out = {}
-    st = pytest.waveforms["coincidence_tutorial"]
+    st = waveform_cache["coincidence_tutorial"]
     for var in range(5):
         st = st.copy()
         for tr in st:
@@ -121,10 +121,10 @@ def dar_attached_picks(bingham_dataset, bingham_dar):
     return bingham_dar
 
 
-@pytest.fixture(scope="class", params=list(pytest.waveforms.keys))
-def stream(request):
-    """ each of the streams in test_data/file_paths"""
-    return pytest.waveforms[request.param]
+# @pytest.fixture(scope="class", params=list(pytest.waveforms.keys))
+# def stream(request):
+#     """ each of the streams in test_data/file_paths"""
+#     return pytest.waveforms[request.param]
 
 
 @pytest.fixture(scope="class")

--- a/tests/test_waveforms/test_get_waveforms.py
+++ b/tests/test_waveforms/test_get_waveforms.py
@@ -1,13 +1,8 @@
 """
 tests for get waveforms
 """
-from pathlib import Path
-
 import obspy
 import pytest
-
-
-test_data_path = Path(pytest.test_data_path)
 
 
 @pytest.fixture(scope="class")

--- a/tests/test_waveforms/test_waveforms_utils.py
+++ b/tests/test_waveforms/test_waveforms_utils.py
@@ -22,14 +22,14 @@ class TestTrimEventStream:
     def stream_with_short_end(self):
         """ snip off some waveform from the end, return the new waveforms with
         the time the waveform was snipped """
-        st = pytest.waveforms["default"]
+        st = obspy.read()
         t1, t2 = st[0].stats.starttime, st[0].stats.endtime
         new_t2 = t2 - 10
         st[0].trim(endtime=new_t2)
         return st, new_t2
 
     # tests
-    def test_trimed(self, stream_with_short_end):
+    def test_trimmed(self, stream_with_short_end):
         """
         test that the max time on the waveforms is t2
         """
@@ -87,7 +87,7 @@ class TestStream2Contiguous:
     @pytest.fixture(scope="class")
     def one_trace_gap_overlaps_stream(self):
         """ a waveforms a gap on one trace """
-        st = pytest.waveforms["default"]
+        st = obspy.read()
         st1 = st.copy()
         st2 = st.copy()
         t1 = st[0].stats.starttime


### PR DESCRIPTION
This PR refactors the test suite to remove the need for the pytest_namespace hook. See [here](https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace) for the pytest depreciation announcement. 
Fixes #33 
