### PR TITLE
fix #49

### DIFF
--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -4,7 +4,17 @@ Constants used throughout obsplus
 import concurrent.futures
 from collections import OrderedDict
 from pathlib import Path
-from typing import Callable, Union, Optional, Mapping, Any, List, Tuple, TypeVar
+from typing import (
+    Callable,
+    Union,
+    Optional,
+    Mapping,
+    Any,
+    List,
+    Tuple,
+    TypeVar,
+    MutableSequence,
+)
 from types import MappingProxyType as MapProx
 
 import numpy as np
@@ -138,6 +148,9 @@ event_clientable_type = Union[Path, str, Catalog, Event, EventClient]
 
 # a events or event type var
 catalog_or_event = TypeVar("catalog_or_event", Catalog, Event)
+
+# trace container (Stream, or any mutable collection)
+trace_sequence = TypeVar("trace_sequence", Stream, MutableSequence[Trace])
 
 # types accepted by DataFetcher for stations info
 inventory_type = Union[Inventory, pd.DataFrame]

--- a/obsplus/waveforms/utils.py
+++ b/obsplus/waveforms/utils.py
@@ -114,7 +114,7 @@ def _make_trace_df(traces):
             "trace": x,
             "nslc": x.id,
             "sr": np.int(np.round(1. / x.stats.sampling_rate, 9) * 1_000_000_000),
-            "start": x.stats.starttime.ns,
+            "start": x.stats.starttime._ns,
             "end": x.stats.endtime._ns,  # TODO switch to .ns for obspy 1.2
         }
         for x in traces

--- a/obsplus/waveforms/utils.py
+++ b/obsplus/waveforms/utils.py
@@ -22,11 +22,11 @@ from obsplus.utils import get_nslc_series
 
 
 def trim_event_stream(
-        stream: Stream,
-        merge: Optional[int] = 1,
-        copy: bool = True,
-        trim_tolerance=None,
-        required_len: Optional[float] = 0.95,
+    stream: Stream,
+    merge: Optional[int] = 1,
+    copy: bool = True,
+    trim_tolerance=None,
+    required_len: Optional[float] = 0.95,
 ):
     """
     Trim the waveforms to a common start time and end time.
@@ -113,7 +113,7 @@ def _make_trace_df(traces):
         {
             "trace": x,
             "nslc": x.id,
-            "sr": np.int(np.round(1. / x.stats.sampling_rate, 9) * 1_000_000_000),
+            "sr": np.int(np.round(1.0 / x.stats.sampling_rate, 9) * 1_000_000_000),
             "start": x.stats.starttime._ns,
             "end": x.stats.endtime._ns,  # TODO switch to .ns for obspy 1.2
         }
@@ -166,10 +166,10 @@ def merge_traces(st: trace_sequence, inplace=False) -> obspy.Stream:
         y = np.ones_like(t) * np.NaN
         for tr in gtraces:
             start_ind = np.searchsorted(t, tr.stats.starttime._ns)
-            y[start_ind: start_ind + len(tr.data)] = tr.data
+            y[start_ind : start_ind + len(tr.data)] = tr.data
         gtraces.iloc[0].data = y
         merged_traces.append(gtraces.iloc[0])
-        assert not np.any(np.isnan(y)), 'nan values remaining!'
+        assert not np.any(np.isnan(y)), "nan values remaining!"
     return obspy.Stream(traces=merged_traces)
 
 
@@ -252,13 +252,13 @@ def _get_waveforms_bulk_naive(self, bulk_arg):
 
 
 def archive_to_sds(
-        bank: Union[Path, str, "obsplus.WaveBank"],
-        sds_path: Union[Path, str],
-        starttime: Optional[UTCDateTime] = None,
-        endtime: Optional[UTCDateTime] = None,
-        overlap: float = 30,
-        type_code: str = "D",
-        stream_processor: Optional[callable] = None,
+    bank: Union[Path, str, "obsplus.WaveBank"],
+    sds_path: Union[Path, str],
+    starttime: Optional[UTCDateTime] = None,
+    endtime: Optional[UTCDateTime] = None,
+    overlap: float = 30,
+    type_code: str = "D",
+    stream_processor: Optional[callable] = None,
 ):
     """
     Create a seiscomp data structure archive from a waveform source.

--- a/profiling/profile_wavebank.ipynb
+++ b/profiling/profile_wavebank.ipynb
@@ -72,17 +72,16 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "604 ms ± 6.09 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%timeit index_update()\n"
+    "# %timeit index_update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profile yielding traces"
    ]
   },
   {
@@ -91,8 +90,106 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# shutil.rmtree(str(test_dir))"
+    "index = wb.read_index()\n",
+    "start = index.starttime.min()\n",
+    "end = start + 48 * 3600 * 2"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1970-01-01T00:00:00.000000Z 1970-01-05T00:00:00.000000Z\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(obspy.UTCDateTime(start), obspy.UTCDateTime(end))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 18.4 s, sys: 395 ms, total: 18.8 s\n",
+      "Wall time: 18.8 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "for st in wb.yield_waveforms(starttime=start, endtime=end, duration=3600, overlap=2):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profile getting stream from bank"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "798 ms ± 4.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit st = wb.get_waveforms(starttime=start, endtime=start+3600*2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%load_ext snakeviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/tmp/tmpfivex5w5'. \n"
+     ]
+    }
+   ],
+   "source": [
+    "#%%snakeviz\n",
+    "#st = wb.get_waveforms(starttime=start, endtime=start+3600*2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/profiling/profile_wavebank.ipynb
+++ b/profiling/profile_wavebank.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,35 +97,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1970-01-01T00:00:00.000000Z 1970-01-05T00:00:00.000000Z\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(obspy.UTCDateTime(start), obspy.UTCDateTime(end))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 18.4 s, sys: 395 ms, total: 18.8 s\n",
-      "Wall time: 18.8 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "for st in wb.yield_waveforms(starttime=start, endtime=end, duration=3600, overlap=2):\n",
@@ -141,24 +124,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "798 ms ± 4.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# profile loading and joining many traces\n",
     "%timeit st = wb.get_waveforms(starttime=start, endtime=start+3600*2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# profile trimming part of a trace\n",
+    "%timeit st = wb.get_waveforms(starttime=start + 10, endtime=start + 70)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,18 +153,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " \n",
-      "*** Profile stats marshalled to file '/tmp/tmpfivex5w5'. \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#%%snakeviz\n",
     "#st = wb.get_waveforms(starttime=start, endtime=start+3600*2)"

--- a/tests/test_waveforms/test_waveforms_utils.py
+++ b/tests/test_waveforms/test_waveforms_utils.py
@@ -83,7 +83,7 @@ class TestMegeStream:
         st1 = obspy.read()
         st2 = obspy.read()
         for tr1, tr2 in zip(st1, st2):
-            tr2.stats.starttime = tr1.stats.endtime + 1. / tr2.stats.sampling_rate
+            tr2.stats.starttime = tr1.stats.endtime + 1.0 / tr2.stats.sampling_rate
         st_in = st1 + st2
         out = merge_traces(st_in)
         assert len(out) == 3


### PR DESCRIPTION
Fixes issue 49. Adds a `merge_traces` method to obsplus.waveforms.utils that is faster than obspy's merge traces by about 80%, and will not form traces with masked arrays. 