### PR TITLE
Merge dtype

### DIFF
--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -239,6 +239,27 @@ EVENT_ATTRS = (
     "preferred_focal_mechanism_id",
 )
 
+# Numpy int types
+NUMPY_INT_TYPES = {
+    np.int,
+    np.int32,
+    np.int64,
+    np.uint,
+    np.dtype("int32"),
+    np.dtype("int64"),
+}
+
+# Numpy float types
+NUMPY_FLOAT_TYPES = {
+    np.float32,
+    np.float64,
+    np.float16,
+    np.float128,
+    np.dtype("float32"),
+    np.dtype("float64"),
+    np.dtype("float128"),
+}
+
 # ------------------------ wavefetcher/bank stuff
 
 # the attrs that can be overwritten temporarily

--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -57,12 +57,6 @@ def _temporary_override(func):
             self.set_events(kwargs.pop("events", self.event_client))
             self.set_stations(kwargs.pop("stations", self.station_client))
             self.set_waveforms(kwargs.pop("waveforms", self.waveform_client))
-            # init_kwargs = dict(
-            #     events=kwargs.pop('events', self.event_client),
-            #     waveforms=kwargs.pop('waveforms', self.waveform_client),
-            #     stations=kwargs.pop('stations', self.station_client),
-            # )
-            # self = Fetcher(**init_kwargs)
 
         return func(self, *args, **kwargs)
 

--- a/tests/test_structures/test_fetcher.py
+++ b/tests/test_structures/test_fetcher.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import obspy
 import pandas as pd
 import pytest
@@ -396,9 +397,9 @@ class TestStreamProcessor:
 
         def stream_processor(st: obspy.Stream) -> obspy.Stream:
             """ select the z component, detrend, and filter a waveforms """
-            st = st.select(component="Z")
-            st.detrend("linear")
-            st.filter("bandpass", freqmin=1, freqmax=10)
+            # st = st.select(component="Z")
+            # st.detrend("linear")
+            # st.filter("bandpass", freqmin=1, freqmax=10)
             return st
 
         new_fetcher.stream_processor = stream_processor
@@ -719,7 +720,7 @@ class TestGetEventData:
         path to tempdir """
         path = os.path.join(temp_dir_path, self.path)
         params = dict(time_before_origin=0, time_after_origin=10, path=path)
-
+        breakpoint()
         fetcher.download_event_waveforms(**params)
         return temp_dir_path
 

--- a/tests/test_structures/test_fetcher.py
+++ b/tests/test_structures/test_fetcher.py
@@ -397,9 +397,9 @@ class TestStreamProcessor:
 
         def stream_processor(st: obspy.Stream) -> obspy.Stream:
             """ select the z component, detrend, and filter a waveforms """
-            # st = st.select(component="Z")
-            # st.detrend("linear")
-            # st.filter("bandpass", freqmin=1, freqmax=10)
+            st = st.select(component="Z")
+            st.detrend("linear")
+            st.filter("bandpass", freqmin=1, freqmax=10)
             return st
 
         new_fetcher.stream_processor = stream_processor
@@ -720,7 +720,6 @@ class TestGetEventData:
         path to tempdir """
         path = os.path.join(temp_dir_path, self.path)
         params = dict(time_before_origin=0, time_after_origin=10, path=path)
-        breakpoint()
         fetcher.download_event_waveforms(**params)
         return temp_dir_path
 

--- a/tests/test_waveforms/test_waveforms_utils.py
+++ b/tests/test_waveforms/test_waveforms_utils.py
@@ -70,6 +70,14 @@ class TestTrimEventStream:
 class TestMegeStream:
     """ Tests for obsplus' style for merging streams together. """
 
+    def convert_stream_dtype(self, st, dtype):
+        """ Convert datatypes on each trace in the stream. """
+        st = st.copy()
+        for tr in st:
+            tr.data = tr.data.astype(dtype)
+            assert tr.data.dtype == dtype
+        return st
+
     def test_identical_streams(self):
         """ ensure passing identical streams performs de-duplication. """
         st = obspy.read()
@@ -109,6 +117,30 @@ class TestMegeStream:
         st_in = st1 + st2
         st_out = merge_traces(st_in)
         assert st_out == st_in
+
+    def test_array_data_type(self):
+        """ The array datatype should not change. """
+        # test floats
+        st1 = obspy.read()
+        st2 = obspy.read()
+        st_out1 = merge_traces(st1 + st2)
+        for tr1, tr2 in zip(st_out1, st1):
+            assert tr1.data.dtype == tr2.data.dtype
+        # tests ints
+        st3 = self.convert_stream_dtype(st1, np.int32)
+        st4 = self.convert_stream_dtype(st1, np.int32)
+        st_out2 = merge_traces(st3 + st4)
+        for tr in st_out2:
+            assert tr.data.dtype == np.int32
+        # def test one int one float
+        breakpoint()
+        st_out3 = merge_traces(st1 + st3)
+        for tr in st_out3:
+            assert tr.data.dtype == np.float64
+        # ensure order of traces doesn't mater for dtypes
+        st_out4 = merge_traces(st3 + st1)
+        for tr in st_out4:
+            assert tr.data.dtype == np.float64
 
 
 class TestStream2Contiguous:

--- a/tests/test_waveforms/test_waveforms_utils.py
+++ b/tests/test_waveforms/test_waveforms_utils.py
@@ -133,7 +133,6 @@ class TestMegeStream:
         for tr in st_out2:
             assert tr.data.dtype == np.int32
         # def test one int one float
-        breakpoint()
         st_out3 = merge_traces(st1 + st3)
         for tr in st_out3:
             assert tr.data.dtype == np.float64


### PR DESCRIPTION
Fixes `obsplus.waveforms.utils.merge_traces` to preserve proper datatypes. 