### PR TITLE
ensure no None strings are returned from indices

### DIFF
--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -182,13 +182,17 @@ class _IndexCache:
         if not len(cached_index):  # query is not cached get it from cache
             where = get_kernel_query(starttime, endtime, buffer=buffer)
             index = self._get_index(where, **kwargs)
+            # replace "None" with None
+            ic = self.bank.index_str
+            index.loc[:, ic] = index.loc[:, ic].replace(["None"], [None])
             self._set_cache(index, starttime, endtime, kwargs)
         else:
             index = cached_index.iloc[0]["cindex"]
         # trim down index
         con1 = index.starttime >= (endtime + buffer)
         con2 = index.endtime <= (starttime - buffer)
-        return index[~(con1 | con2)]
+        df = index[~(con1 | con2)]
+        return df
 
     def _set_cache(self, index, starttime, endtime, kwargs):
         """ cache the current index """
@@ -353,6 +357,7 @@ def _read_table(table_name, con, columns=None, **kwargs) -> pd.DataFrame:
 
     """
     sql = _make_sql_command("select", table_name, columns=columns, **kwargs)
+    # replace "None" with None
     return pd.read_sql(sql, con)
 
 

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -35,7 +35,7 @@ def _get_event_description(event):
     """ return a string of the first event description. """
     try:
         return event.event_descriptions[0].text
-    except:
+    except (AttributeError, IndexError, TypeError):
         return None
 
 

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -232,6 +232,14 @@ class TestReadIndexQueries:
         with pytest.raises(ValueError):
             bing_ebank.read_index(minradius=20)
 
+    def test_no_none_strs(self, bing_ebank):
+        """
+        There shouldn't be any None strings in the df.
+        These should have been replaced with proper None values.
+        """
+        df = bing_ebank.read_index()
+        assert not (df == "None").any().any()
+
 
 class TestGetEvents:
     """ tests for pulling events out of the bank """

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -432,6 +432,14 @@ class TestGetIndex:
         df = bank.read_index(starttime=utc1, endtime=utc2)
         assert (df.groupby("station").size() == 3).all()
 
+    def test_no_none_strs(self, ta_bank_index):
+        """
+        There shouldn't be any None strings in the df.
+        These should have been replaced with proper None values.
+        """
+        df = ta_bank_index.read_index()
+        assert not (df == "None").any().any()
+
 
 class TestYieldStreams:
     """ tests for yielding streams from the bank """

--- a/tests/test_events/test_validate.py
+++ b/tests/test_events/test_validate.py
@@ -131,9 +131,9 @@ class TestValidateCatalog:
     @pytest.fixture
     def cat_nullish_nslc_codes(self, cat1):
         """ Create several picks with nullish location codes. """
-        cat1[0].picks[0].waveform_id.location = "--"
-        cat1[0].picks[1].waveform_id.location = None
-        return cat1
+        cat1[0].picks[0].waveform_id.location_code = "--"
+        cat1[0].picks[1].waveform_id.location_code = None
+        return validate_catalog(cat1)
 
     # tests
     def test_pcat1_cleared_preferreds(self, cat1_cleared_preferreds):


### PR DESCRIPTION
This PR is to simply ensure there are no "None" values in a dataframe returned from `read_index` of `WaveBank` or `EventBank`. 