### PR TITLE
fix #55

### DIFF
--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -99,19 +99,37 @@ EVENT_DTYPES = MapProx(
 EVENT_COLUMNS = tuple(EVENT_DTYPES)
 
 # columns required for picks
-PICK_COLUMNS = (
-    "resource_id",
-    "event_id",
-    "event_time",
-    "phase_hint",
-    "onset",
-    "polarity",
-    "time",
-    "network",
-    "station",
-    "location",
-    "channel",
-)
+
+PICK_DTYPES = {
+    "resource_id": str,
+    "time": float,
+    "seed_id": str,
+    "filter_id": str,
+    "method_id": str,
+    "horizontal_slowness": float,
+    "backazimuth": float,
+    "onset": str,
+    "phase_hint": str,
+    "polarity": str,
+    "evaluation_mode": str,
+    "event_time": float,
+    "evaluation_status": str,
+    "creation_time": float,
+    "author": str,
+    "agency_id": str,
+    "event_id": str,
+    "network": str,
+    "station": str,
+    "location": str,
+    "channel": str,
+    "uncertainty": float,
+    "lower_uncertainty": float,
+    "upper_uncertainty": float,
+    "confidence_level": float,
+}
+
+PICK_COLUMNS = tuple(PICK_DTYPES)
+
 
 # keys used to identify UTC objects
 UTC_KEYS = ("creation_time", "time", "reference")

--- a/obsplus/structures/dfextractor.py
+++ b/obsplus/structures/dfextractor.py
@@ -83,7 +83,7 @@ class DataFrameExtractor(UserDict):
         self._func = singledispatch(self._base_call)
         self._base_required_columns = required_columns
         self._dtypes = [dtypes] if dtypes is not None else []
-        self.utc_columns = utc_columns
+        self.utc_columns = utc_columns or ()
         if pass_dataframe:
             self._func.register(pd.DataFrame)(_pass_through_dataframe)
 
@@ -198,7 +198,7 @@ class DataFrameExtractor(UserDict):
         assert isinstance(df, pd.DataFrame), "must return a DataFrame instance"
         if not df.empty:  # if df is not empty it should have all the columns
             # read in any UTCDateTime
-            for col in iterate(self.utc_columns):
+            for col in set(iterate(self.utc_columns)) & set(df.columns):
                 df[col] = df[col].apply(_timestampit)
         replace, dtypes = {"nan": ""}, self.dtypes
         required_cols = self._base_required_columns

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -179,6 +179,8 @@ def order_columns(
         A sequence that contains the column names
     dtype
         A dictionary of dtypes
+    replace
+        Input passed to DataFrame.Replace
     Returns
     -------
     pd.DataFrame


### PR DESCRIPTION
This PR adds logic to extract information from the `time_errors` of `obspy.core.event.Pick` object, as per the request in #55.
