### PR TITLE
refactor fetcher and bank

### DIFF
--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -12,7 +12,7 @@ import pandas as pd
 from pandas.io.sql import DatabaseError
 
 import obsplus
-from obsplus.bank.utils import iter_files
+from obsplus.utils import iter_files
 from obsplus.exceptions import BankDoesNotExistError
 
 
@@ -116,8 +116,11 @@ class _Bank(ABC):
 
     def _unindexed_file_iterator(self):
         """ return an iterator of potential unindexed waveform files """
-        # on rare occasions mtimes
-        mtime = self.last_updated - 0.001 if self.last_updated is not None else None
+        # get mtime, subtract a bit to avoid odd bugs
+        mtime = None
+        if self.last_updated is not None:
+            mtime = self.last_updated - 0.001
+        # return file iterator
         return iter_files(self.bank_path, ext=self.ext, mtime=mtime)
 
     def _make_meta_table(self):

--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -235,35 +235,6 @@ def sql_connection(path, **kwargs):
         yield con
 
 
-def iter_files(path, ext=None, mtime=None, skip_hidden=True):
-    """
-    use os.scan dir to iter files, optionally only for those with given
-    extension (ext) or modified times after mtime
-
-    Parameters
-    ----------
-    path : str
-        The path to the base directory to traverse.
-    ext : str or None
-        The extensions to map.
-    mtime : int or float
-        Time stamp indicating the minimum mtime.
-    skip_hidden : bool
-        If True skip files that begin with a '.'
-
-    Returns
-    -------
-
-    """
-    for entry in os.scandir(path):
-        if entry.is_file() and (ext is None or entry.name.endswith(ext)):
-            if mtime is None or entry.stat().st_mtime >= mtime:
-                if entry.name[0] != "." or not skip_hidden:
-                    yield entry.path
-        elif entry.is_dir():
-            yield from iter_files(entry.path, ext=ext, mtime=mtime)
-
-
 def get_kernel_query(starttime: float, endtime: float, buffer: float):
     """" get the HDF5 kernel query parameters (this is necessary because
     hdf5 doesnt accept invert conditions for some reason. A slight buffer

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -20,11 +20,10 @@ import obspy
 import obspy.clients.fdsn
 import pandas as pd
 import pytest
-from obsplus.bank.wavebank import WaveBank, filter_index
-from obsplus.bank.utils import iter_files
+from obsplus.bank.wavebank import WaveBank
 from obsplus.constants import NSLC
 from obsplus.exceptions import BankDoesNotExistError
-from obsplus.utils import make_time_chunks
+from obsplus.utils import make_time_chunks, filter_index, iter_files
 from obspy import UTCDateTime as UTC
 
 
@@ -345,7 +344,7 @@ class TestBankBasics:
         index = crandall_dataset.waveform_client.read_index(network="UU")
         t1 = index.starttime.mean()
         t2 = index.endtime.max()
-        bool_ind = filter_index(index, "UU", "*", "*", "*", start=t1, end=t2)
+        bool_ind = filter_index(index, "UU", "*", "*", "*", starttime=t1, endtime=t2)
         out = index[bool_ind]
         assert len(out) < len(index)
 

--- a/wip/wavecache.py
+++ b/wip/wavecache.py
@@ -10,7 +10,7 @@ import obspy
 import pandas as pd
 
 import obsplus
-from obsplus.bank.wavebank import filter_index
+from obsplus.utils import filter_index
 
 processor_type = Callable[[obspy.Stream], obspy.Stream]
 


### PR DESCRIPTION
This PR does a few things:

1) Extracts the `filter_index` function from obsplus.bank.utils to obsplus.utils so it can be used by `Fetcher` for filtering inventory dataframes.

2) formatting fixes

3) changes `WaveBank._read_metadata` to only call `_ensure_meta_table_exists` after a read attempt fails.

4) Fixes issue #46 