### PR TITLE
refactor filter df

### DIFF
--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -280,7 +280,9 @@ class WaveBank(_Bank):
         # grab index from cache
         index = self._index_cache(starttime, endtime, buffer=self.buffer, **kwargs)
         # filter and return
-        filt = filter_index(index, network, station, location, channel)
+        filt = filter_index(
+            index, network=network, station=station, location=location, channel=channel
+        )
         return index[filt]
 
     def _read_metadata(self):

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -337,17 +337,6 @@ class TestBankBasics:
         bank.put_waveforms(obspy.read())
         assert len(bank.read_index()) == 3
 
-    def test_filter_index(self, crandall_dataset):
-        """ Tests for filtering index with filter index function. """
-        # this is mainly here to test the time filtering, because the bank
-        # operations pass this of to the HDF5 kernel.
-        index = crandall_dataset.waveform_client.read_index(network="UU")
-        t1 = index.starttime.mean()
-        t2 = index.endtime.max()
-        bool_ind = filter_index(index, "UU", "*", "*", "*", starttime=t1, endtime=t2)
-        out = index[bool_ind]
-        assert len(out) < len(index)
-
 
 class TestEmptyBank:
     """ tests for graceful handling of empty sbanks"""


### PR DESCRIPTION
This PR refactors how the `filter_index` function works by breaking it into two functions, one for handling start/end times and the other for handling generic matching. 