### PR TITLE
Fix 61

### DIFF
--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -43,6 +43,7 @@ from obsplus.utils import (
     thread_lock_function,
     get_nslc_series,
     filter_index,
+    replace_null_nlsc_codes,
 )
 from obsplus.waveforms.utils import merge_traces
 
@@ -660,6 +661,8 @@ class WaveBank(_Bank):
         for st in (_try_read_stream(x, **kwargs) for x in files):
             if st is not None and len(st):
                 stt += st
+        # sort out nullish nslc codes
+        stt = replace_null_nlsc_codes(stt)
         # filter out any traces not in index (this can happen when files hold
         # multiple traces).
         nslc = set(get_nslc_series(index))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,6 +98,12 @@ class TestGetReferenceTime:
         t_out = obsplus.utils.get_reference_time(event_only_picks)
         assert t_expected == t_out
 
+    def test_stream(self):
+        """ Ensure the start of the stream is returned. """
+        st = obspy.read()
+        out = obsplus.utils.get_reference_time(st)
+        assert out == min([tr.stats.starttime for tr in st])
+
 
 class TestIterate:
     def test_none(self):


### PR DESCRIPTION
Provides a fix to issue #61, also adds the ability to use traces and streams with `obsplus.utils.get_reference_time`. 