### PR TITLE
New validate

### DIFF
--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -17,7 +17,6 @@ from obsplus.utils import yield_obj_parent_attr, replace_null_nlsc_codes
 
 CATALOG_VALIDATORS = []
 
-
 def _none_or_type(obj, type_check):
     """ return if obj is None or of type type_check """
     if obj is None:
@@ -35,7 +34,7 @@ def catalog_validator(func):
 
 
 @catalog_validator
-def set_preferred_values(event: Event):
+def set_preferred_values(event: Event, **kwargs):
     """ set the preferred values to the last in the list if they are not
     defined """
     if not event.preferred_origin_id and len(event.origins):
@@ -48,7 +47,7 @@ def set_preferred_values(event: Event):
 
 
 @catalog_validator
-def attach_all_resource_ids(event: Event):
+def attach_all_resource_ids(event: Event, **kwargs):
     """ recurse all objects in a events and set referred objects """
     rid_to_object = {}
     # first pass, bind all resource ids to parent
@@ -67,7 +66,7 @@ def attach_all_resource_ids(event: Event):
 
 
 @catalog_validator
-def check_arrivals_pick_id(event: Event):
+def check_arrivals_pick_id(event: Event, **kwargs):
     """ check that all arrivals link to a pick object, if they are not
      attached set the referred object attr """
     pick_dict = {x.resource_id.id: x for x in event.picks}
@@ -83,7 +82,7 @@ def check_arrivals_pick_id(event: Event):
 
 
 @catalog_validator
-def check_origins(event: Event):
+def check_origins(event: Event, **kwargs):
     """ check the origins and types """
     for ori in event.origins:
         for atr in ORIGIN_FLOATS:
@@ -99,11 +98,173 @@ def check_origins(event: Event):
                 assert _none_or_type(at.confidence_level, float)
 
 
+@catalog_validator
+def check_picks(event: Event, **kwargs):
+    """
+    Checks for errors with phase picks on each station
+
+    This function will check for duplicate picks on each station (i.e. more
+    than one P or S per station), if there are any S or IAML picks before
+    P picks on each station, and if there are more than one IAML pick per 
+    channel.
+    """
+    pdf = obsplus.picks_to_df(event)
+    pdf = pdf.loc[pdf.evaluation_status != "rejected"]
+
+    def dup_picks(phase_hint, df=pdf, event_id=event.resource_id.id, 
+                  on='station'):
+        df = df.loc[df.phase_hint == phase_hint]
+        bad = df.loc[df[on].duplicated()][on].tolist()
+        assert len(bad) == 0, (
+            f'Duplicate {phase_hint} picks found\n'
+            f'event_id: {event_id}, '
+            f'{on}/s: {bad}')
+    
+    def pick_order(g, sp, ap, event_id=event.resource_id.id):
+        # Check P before S
+        temp = {'P','S'}
+        if temp.issubset(g.phase_hint):
+            p_pick = g.loc[g.phase_hint == "P"].iloc[0]
+            s_pick = g.loc[g.phase_hint == "S"].iloc[0]
+            if p_pick.time > s_pick.time:
+                sp.append(g.name)
+        # Check P before IAML
+        temp = {'P','IAML'}
+        if temp.issubset(g.phase_hint):
+            p_pick = g.loc[g.phase_hint == "P"].iloc[0]
+            amp_picks = g.loc[g.phase_hint == "IAML"]
+            bad = []
+            for _, amp in amp_picks.iterrows():
+                if p_pick.time > amp.time:
+                    bad.append(amp.seed_id)
+            ap.extend(bad)
+            
+    # Checking for duplicated picks
+    dup_picks('P')
+    dup_picks('S')
+    dup_picks('IAML', on='seed_id')
+    
+    # Checking that picks are in acceptable order
+    gb = pdf.groupby("station")
+    sp = []
+    ap = []
+    gb.apply(pick_order, sp, ap)
+    assert len(sp) == 0, (
+            'S pick found before P pick:\n'
+            f'station/s: {sp}')
+    assert len(ap) == 0, (
+            'IAML pick found before P pick:\n'
+            f'seed_id/s: {ap}')
+    
+    
+@catalog_validator
+def check_p_lims(event: Event, p_lim=None, **kwargs):
+    """
+    Check for P picks that aren't within p_lim of the median pick (if provided)
+    """
+    if p_lim is not None:
+        df = obsplus.picks_to_df(event)
+        df = df.loc[(df.evaluation_status != "rejected") & 
+                    (df.phase_hint == 'P')]
+        med = df.time.median()
+        bad = df.loc[abs(df.time - med) > p_lim]
+        assert len(bad) == 0, (
+                'Outlying P pick found:\n'
+                f'event_id: {event.resource_id.id}, '
+                f'seed_id/s: {bad.seed_id.tolist()}')
+
+
+@catalog_validator
+def check_amp_lims(event: Event, amp_lim=None, **kwargs):
+    """
+    Check for amplitudes that aren't below amp_lim (if provided)
+    """
+    if amp_lim is not None:
+        bad = []
+        for amp in event.amplitudes:
+            if amp.generic_amplitude > amp_lim:
+                wid = amp.waveform_id
+                nslc = (f'{wid.network_code}.{wid.station_code}.'
+                        f'{wid.location_code}.{wid.channel_code}')
+                bad.append(nslc)            
+        assert len(bad) == 0, (
+                'Above limit amplitude found:\n'
+                f'event_id: {event.resource_id.id}, '
+                f'seed_id/s: {bad}')
+
+
+@catalog_validator
+def check_amp_filts(event: Event, filt_amps=None, **kwargs):
+    """
+    Check that all amplitudes have a specified filter id (if provided)
+    """
+    if filt_amps is not None:
+        if type(filt_amps) is ResourceIdentifier:
+            filt_amps = filt_amps.id
+        bad = []
+        bad_filters = []
+        for amp in event.amplitudes:
+            if amp.filter_id.id != filt_amps:
+                wid = amp.waveform_id
+                nslc = (f'{wid.network_code}.{wid.station_code}.'
+                        f'{wid.location_code}.{wid.channel_code}')
+                bad.append(nslc)  
+                if amp.filter_id.id not in bad_filters:
+                    bad_filters.append(amp.filter_id.id)
+        assert len(bad) == 0, (
+                'Unexpected amplitude filter found:\n'
+                f'event_id: {event.resource_id.id}, '
+                f'seed_id/s: {bad}, '
+                f'filters_used: {set(bad_filters)}')   
+
+
+@catalog_validator
+def check_z_amps(event: Event, no_z_amps=False, **kwargs):
+    """
+    Check for IAML picks on Z channels (if no_z_amps is True)
+    """
+    if no_z_amps:
+        df = obsplus.picks_to_df(event)
+        df = df.loc[(df.evaluation_status != "rejected") & 
+                    (df.phase_hint == 'IAML')]
+        bad = df.loc[df.channel.str.endswith('Z')].seed_id.tolist()
+        assert len(bad) == 0, (
+                'Amplitude pick on Z axis found:\n'
+                f'event_id: {event.resource_id.id}, '
+                f'seed_id/s: {bad}')
+        
+        
+@catalog_validator
+def check_amp_times(event: Event, **kwargs):
+    """
+    Check for amplitudes times that don't match the referenced pick time
+    """
+    bad = []
+    for amp in event.amplitudes:
+        if amp.time_window is None:
+            continue
+        amp_t = amp.time_window.reference
+        pick = amp.pick_id.get_referred_object()
+        if (amp_t is None) or (amp_t != pick.time):
+            wid = amp.waveform_id
+            nslc = (f'{wid.network_code}.{wid.station_code}.'
+                    f'{wid.location_code}.{wid.channel_code}')
+            bad.append(nslc)
+    assert len(bad) == 0, (
+            'Mismatched amplitude and pick times found:\n'
+            f'event_id: {event.resource_id.id}, '
+            f'seed_id/s: {bad}, ')      
+
+
+
+
+
 # register the nullish nslc code replacement
 catalog_validator(replace_null_nlsc_codes)
 
 
-def validate_catalog(events: Union[Catalog, Event],) -> Optional[Union[Catalog, Event]]:
+def validate_catalog(events: Union[Catalog, Event], 
+                     **kwargs) -> Optional[Union[Catalog, Event]]:
     """
     Perform tchecks on a events or event object.
 
@@ -115,42 +276,11 @@ def validate_catalog(events: Union[Catalog, Event],) -> Optional[Union[Catalog, 
         The events or event to check
 
     """
+    # TODO: asssert or print bool?
 
     cat = events if isinstance(events, Catalog) else Catalog(events=[events])
     for event in cat:
         for func in CATALOG_VALIDATORS:
-            func(event)
+            func(event, **kwargs)
     return events
 
-
-def check_picks(cat: Catalog):
-    """
-    Checks for errors with phase picks
-
-    This function will check for duplicate picks on each station (i.e. more
-    than one P or S per station) as well as if there are any S picks before
-    P picks on each station.
-
-    Parameters
-    ----------
-    cat
-        Obspy catalog to validate
-
-    """
-
-    def fn(df):
-        # No duplicates
-        assert not any(df.phase_hint.duplicated())
-
-        # Check p before s
-        if ps.issubset(df.phase_hint):
-            p_pick = df.loc[df.phase_hint == "P"].iloc[0]
-            s_pick = df.loc[df.phase_hint == "S"].iloc[0]
-            assert p_pick.time < s_pick.time
-
-    ps = {"P", "S"}
-
-    pdf = obsplus.picks_to_df(cat)
-    pdf = pdf.loc[(pdf.evaluation_status != "rejected") & (pdf.phase_hint.isin(ps))]
-    gb = pdf.groupby(["event_id", "station"])
-    gb.apply(fn)

--- a/tests/test_events/test_validate.py
+++ b/tests/test_events/test_validate.py
@@ -223,8 +223,8 @@ class TestValidateCatalog:
         ensure raise if there are any iaml picks that are before p picks
         """
         cat = cat1.copy()
-        # Moving a iamp time before p time on the same station
-        # picks[23] is a known iamp pick
+        # Moving a iaml time before p time on the same station
+        # picks[23] is a known iaml pick
         # picks[2] is a known p pick 
         cat[0].picks[23].time = cat[0].picks[2].time - 60
         with pytest.raises(AssertionError):
@@ -260,8 +260,8 @@ class TestValidateCatalog:
     def test_z_amps(self, cat1):
         """ ensure raise if there are any IAML picks on Z axis """
         cat = cat1.copy()
-        # Assigning iamp pick to a z channel
-        # picks[23] is a known iamp pick
+        # Assigning iaml pick to a z channel
+        # picks[23] is a known iaml pick
         cat[0].picks[23].waveform_id.channel_code = 'HHZ'
         with pytest.raises(AssertionError):
             validate_catalog(cat, no_z_amps=True)


### PR DESCRIPTION
Added checks (and matching tests) for:
- More than 1 P pick on a station
- More than 1 S pick on a station
- More than 1 IAML pick on a channel
- S picks before P picks on a station
- IAML picks before P picks on a station
- P picks that aren't within p_lim of the median P pick (if p_lim is provided)
- Amplitudes that aren't below amp_lim (if amp_lim is provided)
- Amplitudes that don't have a specific filter id (if filt_amp is provided)
- IAML picks on Z channels (is no_z_amps=True)
- Amplitudes times that don't match the referenced pick time