### PR TITLE
fix #65

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,7 +17,10 @@ obsplus 0.0.1:
   - obsplus.events
     * Added utility function to create origins based on first hit station if
       an event has only picks (see #32).
-    * added utility function for removed rejected orphaned objects from
+    * Added utility function for removed rejected orphaned objects from
       catalog tree (see #63).
+    * Added the init_empty parameter to get_preferred, fixed an issue where
+      an IndexError could get raised (see #65), and moved get_preferred from
+      obsplus.utils to obsplus.events.utils (see #66).
   - obsplus.utils
     * Added method for correcting nullish nslc codes (see #37 and #38)

--- a/obsplus/__init__.py
+++ b/obsplus/__init__.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 # json conversions
 from obsplus.events.json import json_to_cat, cat_to_json, cat_to_dict
-from obsplus.events.utils import bump_creation_version, duplicate_events
+from obsplus.events.utils import bump_creation_version, duplicate_events, get_preferred
 
 # events validation and version bumping
 from obsplus.events.validate import catalog_validator, validate_catalog
@@ -29,7 +29,7 @@ from obsplus.bank.stationbank import StationBank
 Sbank = WaveBank
 
 # misc functions
-from obsplus.utils import get_preferred, get_reference_time
+from obsplus.utils import get_reference_time
 from obsplus.structures.dfextractor import DataFrameExtractor
 
 # package version

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -15,13 +15,8 @@ from obsplus.constants import EVENT_COLUMNS, PICK_COLUMNS, NSLC, PICK_DTYPES
 from obsplus.events.utils import get_reference_time
 from obsplus.interfaces import BankType, EventClient
 from obsplus.structures.dfextractor import DataFrameExtractor
-from obsplus.utils import (
-    read_file,
-    get_preferred,
-    apply_to_files_or_skip,
-    get_instances,
-    getattrs,
-)
+from obsplus.utils import read_file, apply_to_files_or_skip, get_instances, getattrs
+from obsplus import get_preferred
 
 # -------------------- event extractors
 
@@ -76,7 +71,7 @@ origin_dtypes = {x: float for x in ["latitude", "longitude", "depth"]}
 @events_to_df.extractor(dtypes=origin_dtypes)
 def _get_origin_basic(eve):
     """ extract basic info from origin. """
-    ori = get_preferred(eve, "origin")
+    ori = get_preferred(eve, "origin", init_empty=True)
     return getattrs(ori, set(origin_dtypes))
 
 
@@ -102,7 +97,7 @@ def _get_used_stations(origin: ev.Origin, pid):
 def _get_origin_quality(eve: ev.Event):
     """ get information from origin quality """
     # ensure resource_ids in arrivals don't point to picks that dont exist
-    ori = get_preferred(eve, "origin")
+    ori = get_preferred(eve, "origin", init_empty=True)
 
     for pick in eve.picks:
         pick.resource_id.set_referred_object(pick)
@@ -176,7 +171,7 @@ def _get_magnitude_info(eve: ev.Event):
     """ extract magnitude information. Get base magnitude, as well as various
      other magnitude types (where applicable). """
     out = {}
-    magnitude = get_preferred(eve, "magnitude")
+    magnitude = get_preferred(eve, "magnitude", init_empty=True)
     out["magnitude"] = magnitude.mag
     out["magnitude_type"] = magnitude.magnitude_type
     mw = [

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -29,7 +29,6 @@ import obspy
 import obspy.core.event as ev
 import pandas as pd
 from obspy import UTCDateTime as UTC
-from obspy.core.event import Event
 from obspy.core.inventory import Station, Channel
 from obspy.io.mseed.core import _read_mseed as mread
 from obspy.io.quakeml.core import _read_quakeml
@@ -336,47 +335,6 @@ def _get_stream_time(st):
 def _get_trace_time(tr):
     """ return starttime of trace. """
     return tr.stats.starttime
-
-
-def get_preferred(event: Event, what: str):
-    """
-    get the preferred object (eg origin, magnitude) from the event.
-
-    If not defined use the last in the list. If list is empty init empty
-    object.
-    Parameters
-
-    -----------
-    event: obspy.core.event.Event
-        The instance for which the preferred should be sought.
-    what: the preferred item to get
-        Can either be "magnitude", "origin", or "focal_mechanism".
-    """
-    pref_type = {
-        "magnitude": ev.Magnitude,
-        "origin": ev.Origin,
-        "focal_mechanism": ev.FocalMechanism,
-    }
-    prefname = "preferred_" + what
-    whats = what + "s"
-    obj = getattr(event, prefname)()
-    if obj is None:  # get end of list
-        pid = getattr(event, prefname + "_id")
-        if pid is None:  # no preferred id set, return last in list
-            try:  # if there is None return an empty one
-                obj = getattr(event, whats)[-1]
-            except IndexError:  # object has no whats (eg magnitude)
-                return getattr(obspy.core.event, what.capitalize())()
-        else:  # there is an id, it has just come detached, try to find it
-            potentials = {x.resource_id.id: x for x in getattr(event, whats)}
-            if pid.id in potentials:
-                obj = potentials[pid.id]
-            else:
-                var = (pid.id, whats, str(event))
-                warnings.warn("cannot find %s in %s for event %s" % var)
-                obj = getattr(event, whats)[-1]
-    assert isinstance(obj, pref_type[what]), "wrong type returned"
-    return obj
 
 
 def to_timestamp(obj: Optional[Union[str, float, obspy.UTCDateTime]], on_none) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,13 @@ from pathlib import Path
 import obspy
 import pytest
 
+import obsplus
+import obsplus.events.utils
+
 # ------------------------- define constants
 
 # path to the test directory
+
 TEST_PATH = abspath(dirname(__file__))
 # path to the package directory
 PKG_PATH = dirname(TEST_PATH)
@@ -91,7 +95,7 @@ def collect_catalogs():
     """
 
     def _get_origin_time(cat):
-        ori = obsplus.utils.get_preferred(cat, "origin")
+        ori = obsplus.get_preferred(cat, "origin")
         return ori.time
 
     out = {}

--- a/tests/test_events/test_pd_catalog.py
+++ b/tests/test_events/test_pd_catalog.py
@@ -12,10 +12,10 @@ import pandas as pd
 import pytest
 from obspy import UTCDateTime
 
-from obsplus import events_to_df, picks_to_df
+from obsplus import events_to_df, picks_to_df, get_preferred
 from obsplus.constants import EVENT_COLUMNS, PICK_COLUMNS
 from obsplus.datasets.dataloader import base_path
-from obsplus.utils import get_preferred, getattrs, get_nslc_series
+from obsplus.utils import getattrs, get_nslc_series
 
 
 # ---------------- helper functions


### PR DESCRIPTION
This Pr fixes issue #65, adds the `init_empty` parameter to `get_preferred` and moves the `get_preferred` from obsplus.utils to obsplus.events.utils. 