### PR TITLE
Add handling of arbitrary collections for eventid kwarg in read_index

### DIFF
--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -262,11 +262,13 @@ def _make_wheres(queries):
         kwargs.pop("eventid")
     if "event_id" in kwargs:
         val = kwargs.pop("event_id")
-        seq_types = (Sequence, set, np.ndarray)
-        if isinstance(val, seq_types) and not isinstance(val, str):
-            kwargs["event_id"] = [str(x) for x in val]
+        if isinstance(val, str):
+            kwargs["event_id"] = val
         else:
-            kwargs["event_id"] = str(val)
+            try:
+                kwargs["event_id"] = [str(x) for x in val]
+            except TypeError:
+                kwargs["event_id"] = str(val)
     if "endtime" in kwargs:
         kwargs["maxtime"] = kwargs["endtime"]
         kwargs.pop("endtime")

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -221,10 +221,21 @@ class TestReadIndexQueries:
         assert len(df) == 1
         assert eve_id in df.index
 
+    def test_query_resource_id(self, bing_ebank, catalog):
+        """ test query on a resource id """
+        eve_id = catalog[0].resource_id
+        df = bing_ebank.read_index(event_id=eve_id)
+        assert len(df) == 1
+        assert str(eve_id) in df.index
+
     def test_query_event_ids(self, bing_ebank, catalog):
-        """ test querying multiple ids """
-        eve_ids = [str(x.resource_id) for x in catalog]
+        """
+        test querying multiple ids (specifically using something other
+        than a list)
+        """
+        eve_ids = bing_ebank.read_index().iloc[0:2].index
         df = bing_ebank.read_index(eventid=eve_ids)
+        assert len(df) == 2
         assert df.index.isin(eve_ids).all()
 
     def test_bad_param_raises(self, bing_ebank):


### PR DESCRIPTION
Re-arranged the check on the eventid kwarg in _make_wheres to make sure it can take handle collections. Also added a test to explicity verify that it can handle a ResourceIdentifier.