### PR TITLE
Concurrent banking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,8 @@ obsplus 0.0.1:
     * Added better error messages for trying to pull data from banks that do
       not exist (see #36)
     * Event bank eventid param can now accept numpy arrays (see 30).
+    * Added basic file-locking mechanism for wavebank and multiprocessing
+      tests (see #70).
   - obsplus.waveforms
     * Added stack_seed and unstack_seed methods to obsplus data array
       accessors (see #27).

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -185,8 +185,8 @@ class _Bank(ABC):
         # if there is no lock, or this bank owns the lock return
         if not os.path.exists(self.lock_file_path) or self._owns_lock:
             return
-        # get random state, based on process id, for waiting randomw seconds
-        rand = np.random.RandomState(os.getpid() or 0)
+        # get random state, based on process id, for waiting random seconds
+        rand = np.random.RandomState(os.getpid() or 13)
         # wait until the lock file is gone or timeout occurs (then raise)
         count = 0
         while count < max_retry:

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -164,7 +164,7 @@ class _Bank(ABC):
             msg = f"{path} is not a directory, cant read bank"
             raise BankDoesNotExistError(msg)
 
-    def block_on_index_lock(self, wait_interval=1, max_retry=6):
+    def block_on_index_lock(self, wait_interval=.2, max_retry=10):
         """
         Blocks until the lock is released.
 

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -36,7 +36,7 @@ class _Bank(ABC):
     bank_path = ""
     namespace = ""
     index_name = ".index.h5"  # name of index file
-    _lock_file_name = '.~obsplus_hdf5.lock'
+    _lock_file_name = ".~obsplus_hdf5.lock"
     _owns_lock = False
     # optional str defining the directory structure and file name schemes
     path_structure = None
@@ -176,7 +176,7 @@ class _Bank(ABC):
         max_retry
             The number of times to retry before raising.
         """
-        print(f'waiting for index lock {self.tnum}')
+        print(f"waiting for index lock {self.tnum}")
         # if there is no lock, or this bank owns the lock return
         if not os.path.exists(self.lock_file_path) or self._owns_lock:
             return
@@ -189,9 +189,11 @@ class _Bank(ABC):
             count += 1
         else:
             duration = max_retry * wait_interval
-            msg = (f'{self.lock_file_path} was not released after '
-                   f'{duration} seconds. It may need to be manually deleted'
-                   f' if the index is not in the process of being updated.')
+            msg = (
+                f"{self.lock_file_path} was not released after "
+                f"{duration} seconds. It may need to be manually deleted"
+                f" if the index is not in the process of being updated."
+            )
             # import traceback
             # msg += ''.join([str(x) for x in traceback.format_stack()])
             raise BankIndexLockError(msg)
@@ -202,9 +204,9 @@ class _Bank(ABC):
         Acquire lock for work inside context manager.
         """
         self.block_on_index_lock()  # ensure lock isn't already in use
-        print(f'locked index {self.tnum}')
+        print(f"locked index {self.tnum}")
         assert Path(self.bank_path).exists()
-        open(self.lock_file_path, 'w').close()  # create lock file
+        open(self.lock_file_path, "w").close()  # create lock file
         self._owns_lock = True
         yield
         try:
@@ -212,11 +214,4 @@ class _Bank(ABC):
         except FileNotFoundError:
             pass
         self._owns_lock = False
-        print(f'released index lock {self.tnum}')
-
-
-
-
-
-
-
+        print(f"released index lock {self.tnum}")

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -1,8 +1,10 @@
 """
 Bank ABC
 """
+import gc
 import os
 import time
+import tables
 import threading
 import warnings
 from abc import ABC, abstractmethod
@@ -208,6 +210,10 @@ class _Bank(ABC):
         assert Path(self.bank_path).exists()
         open(self.lock_file_path, "w").close()  # create lock file
         self._owns_lock = True
+        # close all open files (nothing should have tables at this point)
+        gc.collect()  # must call GC to ensure everything is cleaned up (ugly)
+        tables.file._open_files.close_all()
+        print(tables.file._FILE_OPEN_POLICY)
         yield
         try:
             os.unlink(self.lock_file_path)

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -164,7 +164,7 @@ class _Bank(ABC):
             msg = f"{path} is not a directory, cant read bank"
             raise BankDoesNotExistError(msg)
 
-    def block_on_index_lock(self, wait_interval=.2, max_retry=10):
+    def block_on_index_lock(self, wait_interval=0.2, max_retry=10):
         """
         Blocks until the lock is released.
 

--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -8,6 +8,7 @@ import re
 import sqlite3
 import warnings
 from functools import singledispatch
+from contextlib import contextmanager
 from os.path import join
 from typing import Optional, Sequence, Union
 

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -213,7 +213,6 @@ class WaveBank(_Bank):
         if len(updates):  # flatten list and make df
             with self.lock_index():
                 self._write_update(list(chain.from_iterable(updates)))
-            self._ensure_meta_table_exists()  # ensures metadata table exists
             # clear cache out when new traces are added
             self._index_cache.clear_cache()
 
@@ -244,6 +243,11 @@ class WaveBank(_Bank):
                 store.append(node, df, append=True, **self.hdf_kwargs)
             # update timestamp
             store.put(self._time_node, pd.Series(time.time()))
+            # make sure meta table also exists.
+            # Note this is hear to avoid opening the store again.
+            if self._meta_node not in store:
+                meta = self._make_meta_table()
+                store.put(self._meta_node, meta, format="table")
 
     def _ensure_meta_table_exists(self):
         """

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -213,7 +213,7 @@ class WaveBank(_Bank):
         if len(updates):  # flatten list and make df
             with self.lock_index():
                 self._write_update(list(chain.from_iterable(updates)))
-            self._read_metadata()  # ensures metadata table exists
+            self._ensure_meta_table_exists()  # ensures metadata table exists
             # clear cache out when new traces are added
             self._index_cache.clear_cache()
 

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -104,10 +104,11 @@ class WaveBank(_Bank):
         this extension will be read.
     concurrent_updates
         If True this bank will share an index with other processes, one or
-        more of which may perform update_index operations. When True a simple
-        file locking mechanism attempts to compensate for shortcommings in
+        more of which may perform update_index operations. When used a simple
+        file locking mechanism attempts to compensate for shortcomings in
         HDF5 stores lack of concurrency support. This is not needed if all
-        processes are only going to read from the bank.
+        processes are only going to read from the bank, nor is it bulletproof,
+        but it should help avoid some issues with a few concurrent processes.
     """
 
     # index columns and types

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -155,7 +155,7 @@ class WaveBank(_Bank):
         """
         self.ensure_bank_path_exists()
         node = self._time_node
-        print(f'reading last updated {self.tnum}')
+        print(f"reading last updated {self.tnum}")
         try:
             out = pd.read_hdf(self.index_path, node)[0]
         except (IOError, IndexError, ValueError, KeyError, AttributeError):
@@ -173,8 +173,9 @@ class WaveBank(_Bank):
         )
 
     @thread_lock_function()
-    def update_index(self, bar: Optional = None, min_files_for_bar: int = 5000,
-                     tnum=None):
+    def update_index(
+        self, bar: Optional = None, min_files_for_bar: int = 5000, tnum=None
+    ):
         """
         Iterate files in bank and add any modified since last update to index.
 
@@ -190,7 +191,7 @@ class WaveBank(_Bank):
             progress bar.
         """
         self.tnum = tnum
-        print(f'updating index! {tnum}')
+        print(f"updating index! {tnum}")
 
         # self._enforce_min_version()
         num_files = sum([1 for _ in self._unindexed_file_iterator()])
@@ -209,7 +210,7 @@ class WaveBank(_Bank):
         getattr(bar, "finish", lambda: None)()  # call finish if applicable
 
         if len(updates):  # flatten list and make df
-            print(f'processing updates {tnum}')
+            print(f"processing updates {tnum}")
 
             with self.lock_index():
                 self._write_update(list(chain.from_iterable(updates)))
@@ -220,7 +221,7 @@ class WaveBank(_Bank):
     def _write_update(self, updates):
         """ convert updates to dataframe, then append to index table """
         # read in dataframe and cast to correct types
-        print(f'starting dataframe formatting {self.tnum}')
+        print(f"starting dataframe formatting {self.tnum}")
         df = pd.DataFrame.from_dict(updates)
         # ensure the bank path is not in the path column
         df["path"] = df["path"].str.replace(self.bank_path, "")
@@ -232,7 +233,7 @@ class WaveBank(_Bank):
             df[float_index] = df[float_index].astype(float)
         # populate index store and update metadata
         assert not df.isnull().any().any(), "null values found in index dataframe"
-        print(f'opening store {self.tnum}')
+        print(f"opening store {self.tnum}")
         try:
             with pd.HDFStore(self.index_path) as store:
                 node = self._index_node
@@ -249,13 +250,13 @@ class WaveBank(_Bank):
                 store.put(self._time_node, pd.Series(time.time()))
         except Exception as e:
             import traceback
-            msg = f'failed at open store {self.tnum} {self._owns_lock}'
+
+            msg = f"failed at open store {self.tnum} {self._owns_lock}"
             print(msg)
             raise ValueError(msg + traceback.print_tb(e.__traceback__))
             strout = traceback.print
 
-        print(f'closing store {self.tnum}')
-
+        print(f"closing store {self.tnum}")
 
     def _ensure_meta_table_exists(self):
         """
@@ -264,7 +265,7 @@ class WaveBank(_Bank):
         if not Path(self.index_path).exists():
             return
         with self.lock_index():
-            print(f'ensureing meta exsits {self.tnum}')
+            print(f"ensureing meta exsits {self.tnum}")
             with pd.HDFStore(self.index_path) as store:
                 # add metadata if not in store
                 if self._meta_node not in store:

--- a/obsplus/exceptions.py
+++ b/obsplus/exceptions.py
@@ -8,3 +8,9 @@ class BankDoesNotExistError(FileNotFoundError):
     Exception raised when the user tries to read data from a bank but the
     bank directory does not exist.
     """
+
+
+class BankIndexLockError(OSError):
+    """
+    Raised when a bank tries to read an index but the lock file is not deleted.
+    """

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1171,6 +1171,7 @@ class TestGetGaps:
 
 class TestBadInputs:
     """ ensure wavebank handles bad inputs correctly """
+
     # tests
     def test_bad_inventory(self, tmp_ta_dir):
         """ ensure giving a bad stations str raises """
@@ -1182,6 +1183,7 @@ class TestConcurrency:
     """
     Tests to make sure running update index in different threads/processes.
     """
+
     worker_count = 4
     new_files = 1
 
@@ -1254,7 +1256,7 @@ class TestConcurrency:
         newbank = WaveBank(ta_bank)
         with ta_bank.lock_index():
             with pytest.raises(BankIndexLockError):
-                newbank.block_on_index_lock(.01, 1)
+                newbank.block_on_index_lock(0.01, 1)
 
 
 class TestSelectDoesntReturnSuperset:

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -6,6 +6,7 @@ import pathlib
 import shutil
 import sys
 import tempfile
+import time
 import types
 from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
 from io import StringIO
@@ -1235,6 +1236,7 @@ class TestConcurrency:
         out = []
         func = functools.partial(self.func, wbank=concurrent_bank)
         for num in range(self.worker_count):
+            time.sleep(.1)
             out.append(process_pool.submit(func))
         return list(as_completed(out))
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1184,10 +1184,10 @@ class TestConcurrency:
     Tests to make sure running update index in different threads/processes.
     """
 
-    worker_count = 6
-    new_files = 10
+    worker_count = 4
+    new_files = 1
 
-    def func(self, wbank, tnum=0):
+    def func(self, wbank, tnum=None):
         """ add new files to the wavebank then update index, return index. """
         path = Path(wbank.bank_path)
         for ind in range(self.new_files):
@@ -1224,9 +1224,7 @@ class TestConcurrency:
     def process_update_index(self, ta_bank, process_pool):
         """ run a bunch of update index operations in different processes,
         return list of results """
-        breakpoint()
         ta_bank.update_index()
-        breakpoint()
         out = []
         for num in range(self.worker_count):
             func = functools.partial(self.func, wbank=ta_bank, tnum=num)
@@ -1252,6 +1250,9 @@ class TestConcurrency:
             x.exception() for x in process_update_index if x.exception() is not None
         ]
         assert len(excs) == 0
+
+    def test_file_lock(self):
+        """ Tests for the file locking mechanism. """
 
 
 class TestSelectDoesntReturnSuperset:

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -59,15 +59,15 @@ class ArchiveDirectory:
     """ class for creating a simple archive """
 
     def __init__(
-            self,
-            path,
-            starttime=None,
-            endtime=None,
-            sampling_rate=1,
-            duration=3600,
-            overlap=0,
-            gaps=None,
-            seed_ids=("TA.M17A..VHZ", "TA.BOB..VHZ"),
+        self,
+        path,
+        starttime=None,
+        endtime=None,
+        sampling_rate=1,
+        duration=3600,
+        overlap=0,
+        gaps=None,
+        seed_ids=("TA.M17A..VHZ", "TA.BOB..VHZ"),
     ):
         self.path = path
         if not os.path.exists(path):
@@ -136,7 +136,7 @@ class ArchiveDirectory:
 
         assert self.starttime and self.endtime, "needs defined times"
         for t1, t2 in make_time_chunks(
-                self.starttime, self.endtime, self.duration, self.overlap
+            self.starttime, self.endtime, self.duration, self.overlap
         ):
             # figure out of this time lies in a gap
             gap = df[~((df.start >= t2) | (df.end <= t1))]
@@ -1183,6 +1183,7 @@ class TestConcurrency:
     """
     Tests to make sure running update index in different threads/processes.
     """
+
     worker_count = 6
     new_files = 10
 
@@ -1191,7 +1192,7 @@ class TestConcurrency:
         path = Path(wbank.bank_path)
         for ind in range(self.new_files):
             st = obspy.read()
-            st.write(f'{path / str(ind)}.mseed', 'mseed')
+            st.write(f"{path / str(ind)}.mseed", "mseed")
         wbank.update_index(tnum=tnum)
         return wbank.read_index()
 
@@ -1247,7 +1248,9 @@ class TestConcurrency:
         """
         assert len(process_update_index) == self.worker_count
         # ensure no exceptions were raised
-        excs = [x.exception() for x in process_update_index if x.exception() is not None]
+        excs = [
+            x.exception() for x in process_update_index if x.exception() is not None
+        ]
         assert len(excs) == 0
 
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1236,7 +1236,7 @@ class TestConcurrency:
         out = []
         func = functools.partial(self.func, wbank=concurrent_bank)
         for num in range(self.worker_count):
-            time.sleep(.1)
+            time.sleep(0.1)
             out.append(process_pool.submit(func))
         return list(as_completed(out))
 


### PR DESCRIPTION
This PR adds a simple file-locking mechanism to `WaveBank` so that it can handle a small number of processes performing concurrent updates. This should be a fairly rare use case, and the implementation should have little impact on other use cases. However, I am not convinced it is bullet proof but the tests are passing. :man_shrugging: 