### PR TITLE
fix small test which can fail on bar update

### DIFF
--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -136,7 +136,8 @@ class TestBankBasics:
 
             def finish(self):
                 pass
-
+        # set the interval to 1 to ensure it gets called
+        ebank_with_bad_files._bar_update_interval = 1
         # remove old index, update with custom bar function
         os.remove(ebank_with_bad_files.index_path)
         with pytest.warns(UserWarning):

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -136,6 +136,7 @@ class TestBankBasics:
 
             def finish(self):
                 pass
+
         # set the interval to 1 to ensure it gets called
         ebank_with_bad_files._bar_update_interval = 1
         # remove old index, update with custom bar function


### PR DESCRIPTION
This fixes a bug found by @sboltz where the test function: test_eventbank.py::TestBankBasics::test_custom_bar  could fail depending on the order the bank events were parsed. 