### PR TITLE
Expand distance df

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,5 +26,5 @@ obsplus 0.0.1:
       obsplus.utils to obsplus.events.utils (see #66).
   - obsplus.utils
     * Added method for correcting nullish nslc codes (see #37 and #38)
-    * Added function for getting source-receiver geometric parameters from
-      any number of events/channels (see #67).
+    * Added function for getting geometric parameters from two groups of
+      events or stations see (see #67/#72).

--- a/docs/notebooks/utils/misc.ipynb
+++ b/docs/notebooks/utils/misc.ipynb
@@ -7,8 +7,8 @@
     "# Miscellaneous Utilities\n",
     "The follow demonstrates some Miscellaneous utilities included in obsplus.\n",
     "\n",
-    "## Source-Receiver DataFrame\n",
-    "Often it is necessary to calculate geometric parameters (distance, azimuth, etc.) from any number of sources to a group of receivers. Obsplus can calculate all of the source-receiver geometric parameters for every event-station pair and store them in a dataframe. This allows for quick look-up at a later point in time, as well as easily calculating statistics like average source-receiver distances. "
+    "## Distance DataFrame\n",
+    "Often it is necessary to calculate geometric parameters (distance, azimuth, etc.) for pairs of entities in two different groups. For example, distance from each event in a catalog to each receiver in an inventory, which allows for quick look-ups for desired pairs, as well as easily calculating statistics . "
    ]
   },
   {
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# create distance dataframe\n",
-    "df = obsplus.utils.get_distance_df(events=cat, stations=inv)\n",
+    "df = obsplus.utils.get_distance_df(entity_1=cat, entity_2=inv)\n",
     "df.head()"
    ]
   },
@@ -63,6 +63,18 @@
    "source": [
     "# or just get a particular parameter\n",
     "print(df.loc[(event_id, seed_id), 'azimuth'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert m to km\n",
+    "df_km = df / 1000.\n",
+    "# Calculate stats for source reseiver distances\n",
+    "df_km.describe().round(decimals=2)"
    ]
   }
  ],

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -130,10 +130,7 @@ PICK_COLUMNS = tuple(PICK_DTYPES)
 # columns for distance dataframe
 
 DISTANCE_DTYES = OrderedDict(
-    distance=float,
-    horizontal_distance=float,
-    depth_distance=float,
-    azimuth=float,
+    distance=float, horizontal_distance=float, depth_distance=float, azimuth=float
 )
 
 DISTANCE_COLUMNS = tuple(DISTANCE_DTYES)

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -130,8 +130,8 @@ PICK_COLUMNS = tuple(PICK_DTYPES)
 # columns for distance dataframe
 
 DISTANCE_DTYES = OrderedDict(
-    epicentral_distance=float,
-    hypocentral_distance=float,
+    distance=float,
+    horizontal_distance=float,
     depth_distance=float,
     azimuth=float,
 )

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -758,62 +758,73 @@ def iter_files(path, ext=None, mtime=None, skip_hidden=True):
             yield from iter_files(entry.path, ext=ext, mtime=mtime)
 
 
-def get_distance_df(events: event_type, stations: inventory_type) -> pd.DataFrame:
+def get_distance_df(
+    entity_1: Union[event_type, inventory_type],
+    entity_2: Union[event_type, inventory_type],
+) -> pd.DataFrame:
     """
     Create a dataframe of distances and azimuths from events to stations.
 
     Parameters
     ----------
-    events
-        Any object from which event information is extractable,
-        eg obspy.Catalog.
-    stations
-        Any object from which station information is extractable,
-        eg obspy.Inventory. Channel-level information must be present.
+    entity_1
+        An object from which latitude, longitude and depth are
+        extractable.
+    entity_2
+        An object from which latitude, longitude and depth are
+        extractable.
 
     Notes
     -----
-    Simply uses obspy.geodetics.gps2dist_azimuth under the hood.
+    Simply uses obspy.geodetics.gps2dist_azimuth under the hood. The index
+    of the dataframe is a multi-index where the first level corresponds to ids
+    from entity_1 (either an event_id or seed_id str) and the second level
+    corresponds to ids from entity_2.
 
     Returns
     -------
-    A dataframe with epicentral, hypocentral, and depth distances, as well as
-    azimuth, from each event to each station.
+    A dataframe with distance, horizontal_distance, and depth distances,
+    as well as azimuth, for each entity pair.
     """
-
     def _dist_func(tup1, tup2):
         """
         Function to get distances and azimuths from pairs of coordinates
         """
         gs_dist, azimuth = gps2dist_azimuth(*tup2[:2], *tup1[:2])[:2]
         z_diff = tup2[2] - tup1[2]
-        hypo_dist = np.sqrt(gs_dist ** 2 + z_diff ** 2)
+        dist = np.sqrt(gs_dist ** 2 + z_diff ** 2)
         out = dict(
-            epicentral_distance=gs_dist,
-            hypocentral_distance=hypo_dist,
+            horizontal_distance=gs_dist,
+            distance=dist,
             depth_distance=z_diff,
             azimuth=azimuth,
         )
         return out
 
-    latlon = ["latitude", "longitude", "elevation"]
-    event_cols = latlon + ["event_id"]
-    sta_cols = latlon + ["seed_id"]
-    # get dataframes of event/station data
-    edf = obsplus.events_to_df(events)
-    edf["elevation"] = -edf["depth"]
-    idf = obsplus.stations_to_df(stations)
-    # get sets of unique lat/lon for stations and events
-    elatlons = set(edf[event_cols].itertuples(index=False, name=None))
-    ilatlons = set(idf[sta_cols].itertuples(index=False, name=None))
+    def _get_distance_tuple(obj):
+        """ return a list of tuples for entities """
+        cols = ['latitude', 'longitude', 'elevation', 'id']
+        try:
+            df = obsplus.events_to_df(obj)
+            df['elevation'] = -df['depth']
+            df['id'] = df['event_id']
+        except (TypeError, ValueError, AttributeError):
+            df = obsplus.stations_to_df(obj)
+            df['id'] = df['seed_id']
+        return set(df[cols].itertuples(index=False, name=None))
+
+    # get a tuple of
+    coord1 = _get_distance_tuple(entity_1)
+    coord2 = _get_distance_tuple(entity_2)
     # make a dict of {(event_id, seed_id): (dist, azimuth)}
     dist_dicts = {
         (ell[-1], ill[-1]): _dist_func(ell, ill)
-        for ell, ill in product(elatlons, ilatlons)
+        for ell, ill in product(coord1, coord2)
+        if ell[-1] != ill[-1]  # skip if same entity
     }
     df = pd.DataFrame(dist_dicts).T.astype(DISTANCE_DTYES)
     # make sure index is named
-    df.index.names = ("event_id", "seed_id")
+    df.index.names = ("id1", "id2")
     return df[list(DISTANCE_COLUMNS)]
 
 

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -786,6 +786,7 @@ def get_distance_df(
     A dataframe with distance, horizontal_distance, and depth distances,
     as well as azimuth, for each entity pair.
     """
+
     def _dist_func(tup1, tup2):
         """
         Function to get distances and azimuths from pairs of coordinates
@@ -803,14 +804,14 @@ def get_distance_df(
 
     def _get_distance_tuple(obj):
         """ return a list of tuples for entities """
-        cols = ['latitude', 'longitude', 'elevation', 'id']
+        cols = ["latitude", "longitude", "elevation", "id"]
         try:
             df = obsplus.events_to_df(obj)
-            df['elevation'] = -df['depth']
-            df['id'] = df['event_id']
+            df["elevation"] = -df["depth"]
+            df["id"] = df["event_id"]
         except (TypeError, ValueError, AttributeError):
             df = obsplus.stations_to_df(obj)
-            df['id'] = df['seed_id']
+            df["id"] = df["seed_id"]
         return set(df[cols].itertuples(index=False, name=None))
 
     # get a tuple of

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """ tests for various utility functions """
+import itertools
 import textwrap
 from pathlib import Path
 
@@ -368,7 +369,7 @@ class TestDistanceDataframe:
     @pytest.fixture(scope="class")
     def distance_df(self, cat, inv):
         """ Return a dataframe from all the crandall events and stations. """
-        return get_distance_df(events=cat, stations=inv)
+        return get_distance_df(entity_1=cat, entity_2=inv)
 
     def test_type(self, distance_df):
         """ ensure a dataframe was returned. """
@@ -377,11 +378,18 @@ class TestDistanceDataframe:
 
     def test_all_events_in_df(self, distance_df, cat):
         """ Ensure all the events are in the distance dataframe. """
-        event_ids_df = set(distance_df.index.to_frame()["event_id"])
+        event_ids_df = set(distance_df.index.to_frame()["id1"])
         event_ids_cat = {str(x.resource_id) for x in cat}
         assert event_ids_cat == event_ids_df
 
     def test_all_seed_id_in_df(self, distance_df, inv):
         seed_id_stations = set(obsplus.stations_to_df(inv)["seed_id"])
-        seed_id_df = set(distance_df.index.to_frame()["seed_id"])
+        seed_id_df = set(distance_df.index.to_frame()["id2"])
         assert seed_id_df == seed_id_stations
+
+    def test_cat_cat(self, cat):
+        """ ensure it works with two catalogs """
+        df = get_distance_df(cat, cat)
+        event_ids = {str(x.resource_id) for x in cat}
+        combinations = set(itertools.permutations(event_ids, 2))
+        assert combinations == set(df.index)


### PR DESCRIPTION
This expands the functionality of `obsplus.utils.get_distance_df` to support either events-like or stations-like objects for either inputs. 