### PR TITLE
Restrict allowable picks for make_origins

### DIFF
--- a/obsplus/events/utils.py
+++ b/obsplus/events/utils.py
@@ -9,7 +9,7 @@ import re
 import warnings
 from functools import lru_cache, singledispatch
 from pathlib import Path
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, Iterable
 
 import obspy
 import obspy.core.event as ev
@@ -243,7 +243,10 @@ def _bump_version(version):
 
 
 def make_origins(
-    events: catalog_or_event, inventory: obspy.Inventory, depth: float = 1.0
+    events: catalog_or_event,
+    inventory: obspy.Inventory,
+    depth: float = 1.0,
+    phases: Optional[Iterable] = None,
 ) -> catalog_or_event:
     """
     Iterate a catalog or single events and ensure each has an origin.
@@ -264,6 +267,9 @@ def make_origins(
     depth
         The default depth for created origins. Should be in meters. See the
         obspy docs for Origin or the quakeml standard for more details.
+    phases
+        List of acceptable phase hints to use for identifying the earliest
+        pick. By default will only search for "P" phase hints.
 
     Returns
     -------
@@ -274,15 +280,23 @@ def make_origins(
     # load inv dataframe and make sure it has a seed_id column
     df = obsplus.stations_to_df(inventory)
     nslc_series = get_nslc_series(df)
+    phases = phases or ["P"]
     for event in cat:
         if not event.origins:  # make new origin
-            assert event.picks, f"{event} has no picks cannot create origin"
+            picks = event.picks_to_df()
+            picks = picks.loc[
+                (~(picks.evaluation_status == "rejected"))
+                & (picks.phase_hint.isin(phases))
+            ]
+            if not len(picks):
+                raise ValueError(f"{event} has no acceptable picks to create origin")
             # get first pick, determine time/station used
-            first_pick = min(event.picks, key=lambda x: x.time.timestamp)
-            seed_id = first_pick.waveform_id.get_seed_string()
+            first_pick = picks.loc[picks.time == picks.time.min()].iloc[0]
+            seed_id = first_pick.seed_id
             # find channel corresponding to pick
             df_chan = df[nslc_series == seed_id]
-            assert len(df_chan), f"{seed_id} not found in inventory"
+            if not len(df_chan):
+                raise KeyError(f"{seed_id} not found in inventory")
             ser = df_chan.iloc[0]
             # create origin
             ori = _create_first_pick_origin(first_pick, ser, depth=depth)
@@ -298,7 +312,7 @@ def _create_first_pick_origin(first_pick, channel_ser, depth):
     )
     comment = ev.Comment(text=msg)
     odict = dict(
-        time=first_pick.time,
+        time=obspy.UTCDateTime(first_pick.time),
         latitude=channel_ser.latitude,
         longitude=channel_ser.longitude,
         depth=depth,

--- a/obsplus/events/utils.py
+++ b/obsplus/events/utils.py
@@ -246,7 +246,7 @@ def make_origins(
     events: catalog_or_event,
     inventory: obspy.Inventory,
     depth: float = 1.0,
-    phases: Optional[Iterable] = None,
+    phase_hints: Optional[Iterable] = ("P", "p"),
 ) -> catalog_or_event:
     """
     Iterate a catalog or single events and ensure each has an origin.
@@ -267,9 +267,9 @@ def make_origins(
     depth
         The default depth for created origins. Should be in meters. See the
         obspy docs for Origin or the quakeml standard for more details.
-    phases
+    phase_hints
         List of acceptable phase hints to use for identifying the earliest
-        pick. By default will only search for "P" phase hints.
+        pick. By default will only search for "P" or "p" phase hints.
 
     Returns
     -------
@@ -280,13 +280,12 @@ def make_origins(
     # load inv dataframe and make sure it has a seed_id column
     df = obsplus.stations_to_df(inventory)
     nslc_series = get_nslc_series(df)
-    phases = phases or ["P"]
     for event in cat:
         if not event.origins:  # make new origin
             picks = event.picks_to_df()
             picks = picks.loc[
                 (~(picks.evaluation_status == "rejected"))
-                & (picks.phase_hint.isin(phases))
+                & (picks.phase_hint.isin(phase_hints))
             ]
             if not len(picks):
                 raise ValueError(f"{event} has no acceptable picks to create origin")

--- a/tests/test_events/test_catalog_utils.py
+++ b/tests/test_events/test_catalog_utils.py
@@ -416,7 +416,7 @@ class TestMakeOrigins:
         )
         eve = ev.Event()
         eve.picks = [pick1, pick2, pick3]
-        return make_origins(events=eve, inventory=inv, phases=["P", "S"]), pick3
+        return make_origins(events=eve, inventory=inv, phase_hints=["P", "S"]), pick3
 
     def test_all_events_have_origins(self, cat_added_origins):
         """ ensure all the events do indeed have origins """

--- a/tests/test_events/test_catalog_utils.py
+++ b/tests/test_events/test_catalog_utils.py
@@ -366,8 +366,13 @@ class TestGetPreferred:
         assert isinstance(ori, ev.Origin)
 
 
-class TestEnsureOrigin:
+class TestMakeOrigins:
     """ Tests for the ensure origin function. """
+
+    @pytest.fixture(scope="class")
+    def inv(self):
+        ds = obsplus.load_dataset("crandall")
+        return ds.station_client.get_stations()
 
     @pytest.fixture(scope="class")
     def cat_only_picks(self, crandall_dataset):
@@ -381,12 +386,37 @@ class TestEnsureOrigin:
         return cat
 
     @pytest.fixture(scope="class")
-    def cat_added_origins(self, cat_only_picks):
-        """ run ensure_origin on the catalog with only picks and return """
+    def cat_added_origins(self, cat_only_picks, inv):
+        """ run make_origins on the catalog with only picks and return """
         # get corresponding inventory
-        ds = obsplus.load_dataset("crandall")
-        inv = ds.station_client.get_stations()
         return make_origins(events=cat_only_picks, inventory=inv)
+
+    @pytest.fixture(scope="class")
+    def strange_picks_added_origins(self, inv):
+        """ make sure "rejected" picks and oddball phase hints get skipped """
+        # Pick w/ good phase hint but bad evaluation status
+        pick1 = ev.Pick(
+            time=obspy.UTCDateTime(),
+            phase_hint="P",
+            evaluation_status="rejected",
+            waveform_id=ev.WaveformStreamID(seed_string="UU.TMU..HHZ"),
+        )
+        # Pick w/ bad phase hint but good evaluation status
+        pick2 = ev.Pick(
+            time=obspy.UTCDateTime(),
+            phase_hint="junk",
+            evaluation_status="reviewed",
+            waveform_id=ev.WaveformStreamID(seed_string="UU.CTU..HHZ"),
+        )
+        # Pick w/ good phase hint and evaluation status
+        pick3 = ev.Pick(
+            time=obspy.UTCDateTime(),
+            phase_hint="S",
+            waveform_id=ev.WaveformStreamID(seed_string="UU.SRU..HHN"),
+        )
+        eve = ev.Event()
+        eve.picks = [pick1, pick2, pick3]
+        return make_origins(events=eve, inventory=inv, phases=["P", "S"]), pick3
 
     def test_all_events_have_origins(self, cat_added_origins):
         """ ensure all the events do indeed have origins """
@@ -401,3 +431,9 @@ class TestEnsureOrigin:
                 assert origin.latitude is not None
                 assert origin.longitude is not None
                 assert origin.depth is not None
+
+    def test_correct_origin_time(self, strange_picks_added_origins):
+        """ make sure newly attached origin used the correct pick to get the location """
+        ori = strange_picks_added_origins[0].origins[0]
+        time = strange_picks_added_origins[1].time
+        assert ori.time == time


### PR DESCRIPTION
In reference to issue #74, added a check to remove rejected picks and picks that do not match a user-specified list of phase hints (by default will just look for "P" phases) when determining the pick to base the origin location/time in the make_origins function. 