### PR TITLE
Stream.get_waveforms to have default params (like WaveBank.get_waveforms)

### DIFF
--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -148,6 +148,10 @@ NSLC = ("network", "station", "location", "channel")
 # the expected dimensions of the standard waveform array
 DIMS = ("stream_id", "seed_id", "time")
 
+# Small and BIG UTCDateTimes
+BIG_UTC = obspy.UTCDateTime("3000-01-01")
+SMALL_UTC = obspy.UTCDateTime("1970-01-01")
+
 # ------------------- type aliases (aliai?)
 
 # The waveforms processor type

--- a/obsplus/waveforms/get_waveforms.py
+++ b/obsplus/waveforms/get_waveforms.py
@@ -1,23 +1,28 @@
 """
 Module for adding the client-like "get_waveforms" to the Stream class
 """
+from typing import Optional
+
 import obspy
 from obspy import Stream, UTCDateTime as UTC
+
+from obsplus.constants import BIG_UTC, SMALL_UTC
 
 
 def get_waveforms(
     stream: Stream,
-    network: str,
-    station: str,
-    location: str,
-    channel: str,
-    starttime: UTC,
-    endtime: UTC,
+    network: str = "*",
+    station: str = "*",
+    location: str = "*",
+    channel: str = "*",
+    starttime: Optional[UTC] = None,
+    endtime: Optional[UTC] = None,
 ):
     """
     A subset of the Client.get_waveforms method.
 
-    Matching is available on all str paramters.
+    Simply makes successive calls to Stream.select and Stream.trim under the
+    hood. Matching is available on all str parameters.
 
     Parameters
     ----------
@@ -42,7 +47,7 @@ def get_waveforms(
     st = stream.select(
         network=network, station=station, location=location, channel=channel
     )
-    st = st.trim(starttime=UTC(starttime), endtime=UTC(endtime))
+    st = st.trim(starttime=UTC(starttime or SMALL_UTC), endtime=UTC(endtime or BIG_UTC))
     return st
 
 

--- a/tests/test_waveforms/test_get_waveforms.py
+++ b/tests/test_waveforms/test_get_waveforms.py
@@ -39,6 +39,10 @@ class TestGetWaveforms:
         assert all([tr.stats.network == "LF" for tr in st])
         assert all([tr.stats.station == "BOB" for tr in st])
 
+    def test_none_times(self, stream):
+        """ Ensure starttime/endtime can be None. """
+        st = stream.get_waveforms("*", "*", "*", "*", None, None)
+
 
 class TestGetWaveformsBulk:
     def test_has_attr(self, stream):


### PR DESCRIPTION
This PR changes `Stream.get_waveforms` to be more similar to `WaveBank.get_waveforms` by adding default parameters. 

This is a bit of a break from the obspy `Client.get_waveforms` in htat it requires all the parameters and has no defaults but since `WaveBank` does  it this way it is probably ok.

@sjohnson5 What do you think? Is this what you wanted?
