### PR TITLE
update_index to return self

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,8 @@ obsplus 0.0.1:
     * Event bank eventid param can now accept numpy arrays (see 30).
     * Added basic file-locking mechanism for wavebank and multiprocessing
       tests (see #70).
+    * Update_index methods now return the bank instance which allows chaining
+      the update call with the init (see #83).
   - obsplus.waveforms
     * Added stack_seed and unstack_seed methods to obsplus data array
       accessors (see #27).

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager, suppress
 from os.path import join
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,9 @@ from pandas.io.sql import DatabaseError
 import obsplus
 from obsplus.exceptions import BankDoesNotExistError, BankIndexLockError
 from obsplus.utils import iter_files
+
+
+BankType = TypeVar("BankType", bound="_Bank")
 
 
 class _Bank(ABC):
@@ -54,7 +57,7 @@ class _Bank(ABC):
         """ read the index filtering on various params """
 
     @abstractmethod
-    def update_index(self):
+    def update_index(self: BankType) -> BankType:
         """ update the index """
 
     @abstractmethod

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -180,7 +180,9 @@ class EventBank(_Bank):
         return df
 
     @thread_lock_function()
-    def update_index(self, bar: Optional = None, min_files_for_bar: int = 100):
+    def update_index(
+        self, bar: Optional = None, min_files_for_bar: int = 100
+    ) -> "EventBank":
         """
         Iterate files in bank and add any modified since last update to index.
 
@@ -220,6 +222,7 @@ class EventBank(_Bank):
         df["path"] = paths
         if len(df):
             self._write_update(self._clean_dataframe(df))
+        return self
 
     def _clean_dataframe(self, df: pd.DataFrame):
         """ clean the dataframe by casting add dtypes """

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -179,7 +179,9 @@ class WaveBank(_Bank):
         )
 
     @thread_lock_function()
-    def update_index(self, bar: Optional = None, min_files_for_bar: int = 5000):
+    def update_index(
+        self, bar: Optional = None, min_files_for_bar: int = 5000
+    ) -> "WaveBank":
         """
         Iterate files in bank and add any modified since last update to index.
 
@@ -215,6 +217,7 @@ class WaveBank(_Bank):
                 self._write_update(list(chain.from_iterable(updates)))
             # clear cache out when new traces are added
             self._index_cache.clear_cache()
+        return self
 
     def _write_update(self, updates):
         """ convert updates to dataframe, then append to index table """

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -197,6 +197,12 @@ class TestBankBasics:
         """ ensure the index version returns the obsplus version. """
         assert ebank._index_version == obsplus.__version__
 
+    def test_update_index_returns_self(self, ebank):
+        """ ensure update index returns the instance for chaining. """
+        out = ebank.update_index()
+        assert out is not None
+        assert out is ebank
+
 
 class TestReadIndexQueries:
     """ tests to ensure the index can be queried """
@@ -256,7 +262,7 @@ class TestReadIndexQueries:
         These should have been replaced with proper None values.
         """
         df = bing_ebank.read_index()
-        assert not (df == "None").any().any()
+        assert not "None" in df.values
 
     def test_event_description_as_set(self, ebank):
         """

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -200,7 +200,6 @@ class TestBankBasics:
     def test_update_index_returns_self(self, ebank):
         """ ensure update index returns the instance for chaining. """
         out = ebank.update_index()
-        assert out is not None
         assert out is ebank
 
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -342,7 +342,6 @@ class TestBankBasics:
     def test_update_index_returns_self(self, default_bank):
         """ ensure update index returns the instance for chaining. """
         out = default_bank.update_index()
-        assert out is not None
         assert out is default_bank
 
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -339,6 +339,12 @@ class TestBankBasics:
         bank.put_waveforms(obspy.read())
         assert len(bank.read_index()) == 3
 
+    def test_update_index_returns_self(self, default_bank):
+        """ ensure update index returns the instance for chaining. """
+        out = default_bank.update_index()
+        assert out is not None
+        assert out is default_bank
+
 
 class TestEmptyBank:
     """ tests for graceful handling of empty sbanks"""
@@ -428,7 +434,7 @@ class TestGetIndex:
         These should have been replaced with proper None values.
         """
         df = ta_bank_index.read_index()
-        assert not (df == "None").any().any()
+        assert "None" not in df.values
 
 
 class TestYieldStreams:


### PR DESCRIPTION
The `update_index` method on both `EventBank` and `WaveBank` will now return the instance. This is useful for chaining bank initialization and update index calls for a slightly smoother API, and shouldn't break any existing code.