### PR TITLE
bulk waveform refactor

### DIFF
--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -317,8 +317,11 @@ stream_proc_type = Callable[[Stream], Stream]
 # The obspy types for waveform data
 wave_type = Union[Stream, Trace, xr.DataArray]
 
+# Type can can be turned into a UTCDateTime
+timable_type = Union[str, UTCDateTime, float]
+
 # waveform request type (args for get_waveforms)
-waveform_request_type = Tuple[str, str, str, str, UTCDateTime, UTCDateTime]
+waveform_request_type = Tuple[str, str, str, str, timable_type, timable_type]
 
 # the signature of obspy fdsn client
 wfcli_type = Callable[[str, str, str, str, UTCDateTime, UTCDateTime], Stream]

--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -437,6 +437,10 @@ class Fetcher:
         get the wave forms using the client, apply processor if it is defined
         """
         out = self.waveform_client.get_waveforms_bulk(*args, **kwargs)
+        if out is None:
+            breakpoint()
+            out = self.waveform_client.get_waveforms_bulk(*args, **kwargs)
+
         if callable(self.stream_processor):
             return self.stream_processor(out) or out
         else:

--- a/obsplus/waveforms/get_waveforms.py
+++ b/obsplus/waveforms/get_waveforms.py
@@ -1,12 +1,18 @@
 """
 Module for adding the client-like "get_waveforms" to the Stream class
 """
-from typing import Optional
+from typing import Optional, List
+from functools import reduce
+from operator import add
 
 import obspy
+import pandas as pd
+import numpy as np
 from obspy import Stream, UTCDateTime as UTC
+from obsplus.utils import _column_contains, get_nslc_series, filter_index
+from obsplus.waveforms.utils import _stream_data_to_df
 
-from obsplus.constants import BIG_UTC, SMALL_UTC
+from obsplus.constants import BIG_UTC, SMALL_UTC, NSLC
 
 
 def get_waveforms(
@@ -51,15 +57,62 @@ def get_waveforms(
     return st
 
 
-def get_waveforms_bulk(stream, bulk_args):
-    """ get bulk waveforms from waveforms """
-    st = obspy.Stream()
-    for arg in bulk_args:
-        stt = get_waveforms(stream, *arg)
-        # if a stream was returned then add it to original
-        if stt is not None:
-            st += stt
-    return st
+def get_waveforms_bulk(st: Stream, bulk: List[str], **kwargs) -> Stream:
+    """
+    Get a large number of waveforms with a bulk request.
+
+    Parameters
+    ----------
+    bulk
+        A list of any number of lists containing the following:
+        (network, station, location, channel, starttime, endtime).
+    index
+        A dataframe returned by read_index. Enables calling code to only
+        read the index from disk once for repetitive calls.
+    """
+    if not bulk:  # return emtpy waveforms if empty list or None
+        return obspy.Stream()
+
+    def _func(time, ind, df, st):
+        """ return waveforms from df of bulk parameters """
+        match_chars = {"*", "?", "[", "]"}
+        ar = np.ones(len(ind))  # indices of ind to use to load data
+        t1, t2 = time[0], time[1]
+        df = df[(df.t1 == time[0]) & (df.t2 == time[1])]
+        # determine which columns use any matching or other select features
+        uses_matches = [_column_contains(df[x], match_chars) for x in NSLC]
+        match_ar = np.array(uses_matches).any(axis=0)
+        df_match = df[match_ar]
+        df_no_match = df[~match_ar]
+        # handle columns that need matches (more expensive)
+        if not df_match.empty:
+            match_bulk = df_match.to_records(index=False)
+            mar = np.array([filter_index(ind, *tuple(b)[:4]) for b in match_bulk])
+            ar = np.logical_and(ar, mar.any(axis=0))
+        # handle columns that do not need matches
+        if not df_no_match.empty:
+            nslc1 = set(get_nslc_series(df_no_match))
+            nslc2 = get_nslc_series(ind)
+            ar = np.logical_and(ar, nslc2.isin(nslc1))
+        # get a list of used traces, combine and trim
+        st = obspy.Stream([x for x, y in zip(st, ar) if y])
+        return st.slice(starttime=UTC(t1), endtime=UTC(t2))
+
+    # get a dataframe of stream contents
+    index = _stream_data_to_df(st)
+    # get a dataframe of the bulk arguments, convert time to float
+    df = pd.DataFrame(bulk, columns=list(NSLC) + ["utc1", "utc2"])
+    df["t1"] = df["utc1"].apply(float)
+    df["t2"] = df["utc2"].apply(float)
+    t1, t2 = df["t1"].min(), df["t2"].max()
+    # filter index and streams to be as short as possible
+    needed = ~((index.starttime > t2) | (index.endtime < t1))
+    ind = index[needed]
+    st = obspy.Stream([tr for tr, bo in zip(st, needed.values) if bo])
+    # groupby.apply calls two times for each time set, avoid this.
+    unique_times = np.unique(df[["t1", "t2"]].values, axis=0)
+    streams = [_func(time, df=df, ind=ind, st=st) for time in unique_times]
+    return reduce(add, streams)
 
 
 # --- add get_waveforms to Stream class


### PR DESCRIPTION
This PR does a few things:

1) Makes the stream `get_waveforms_bulk` much faster

2) Adds a function `obsplus.waveforms.utils.stream_bulk_split` which is similar to `get_waveforms_bulk` except that a stream for each bulk request item is returned in a list

3) Add a few more tests to `WaveBank.get_waveforms_bulk`

and various code cleanup.