### PR TITLE
Stream bulk simplification

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,9 @@ obsplus master:
   - obsplus.bank
     * Speed up wavebank.get_waveforms_bulk by time-filtering index before
       determining which files to read (see #93).
-
+  - obsplus.waveforms
+    * Renamed merge_traces to merge_trim_split and added starttime and endtime
+      params.
 
 obsplus 0.0.1:
   - obsplus.bank

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ obsplus master:
       determining which files to read (see #93).
   - obsplus.waveforms
     * Renamed merge_traces to merge_trim_split and added starttime and endtime
-      params.
+      params (see #94).
 
 obsplus 0.0.1:
   - obsplus.bank

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -630,65 +630,6 @@ def _replace_inv_nulls(inv, null_codes=NULL_NSLC_CODES, replacement_value=""):
     return inv
 
 
-def filter_index_bulk(
-    self, bulk: List[str], index: Optional[pd.DataFrame] = None, **kwargs
-) -> Stream:
-    """
-    Get a large number of waveforms with a bulk request.
-
-    Parameters
-    ----------
-    bulk
-        A list of any number of lists containing the following:
-        (network, station, location, channel, starttime, endtime).
-    index
-        A dataframe returned by read_index. Enables calling code to only
-        read the index from disk once for repetitive calls.
-    """
-    if not bulk:  # return emtpy waveforms if empty list or None
-        return obspy.Stream()
-
-    def _func(time, ind, df):
-        """ return waveforms from df of bulk parameters """
-        breakpoint()
-        match_chars = {"*", "?", "[", "]"}
-        ar = np.ones(len(ind))  # indices of ind to use to load data
-        t1, t2 = time[0], time[1]
-        df = df[(df.t1 == time[0]) & (df.t2 == time[1])]
-        # determine which columns use any matching or other select features
-        uses_matches = [_column_contains(df[x], match_chars) for x in NSLC]
-        match_ar = np.array(uses_matches).any(axis=0)
-        df_match = df[match_ar]
-        df_no_match = df[~match_ar]
-        # handle columns that need matches (more expensive)
-        if not df_match.empty:
-            match_bulk = df_match.to_records(index=False)
-            mar = np.array([filter_index(ind, *tuple(b)[:4]) for b in match_bulk])
-            ar = np.logical_and(ar, mar.any(axis=0))
-        # handle columns that do not need matches
-        if not df_no_match.empty:
-            nslc1 = set(get_nslc_series(df_no_match))
-            nslc2 = get_nslc_series(ind)
-            ar = np.logical_and(ar, nslc2.isin(nslc1))
-        return self._index2stream(ind[ar], t1, t2)
-
-    # get a dataframe of the bulk arguments, convert time to float
-    df = pd.DataFrame(bulk, columns=list(NSLC) + ["utc1", "utc2"])
-    df["t1"] = df["utc1"].apply(float)
-    df["t2"] = df["utc2"].apply(float)
-    # read index that contains any times that might be used, or filter
-    # provided index
-    t1, t2 = df["t1"].min(), df["t2"].max()
-    if index is not None:
-        ind = index[~((index.starttime > t2) | (index.endtime < t1))]
-    else:
-        ind = self.read_index(starttime=t1, endtime=t2)
-    # groupby.apply calls two times for each time set, avoid this.
-    unique_times = np.unique(df[["t1", "t2"]].values, axis=0)
-    streams = [_func(time, df=df, ind=ind) for time in unique_times]
-    return reduce(add, streams)
-
-
 def filter_index(
     index: pd.DataFrame,
     network: Optional = None,

--- a/obsplus/waveforms/utils.py
+++ b/obsplus/waveforms/utils.py
@@ -39,7 +39,7 @@ def trim_event_stream(
     Trim the waveforms to a common start time and end time.
 
     Uses latest start and earliest end for each trace, unless an abnormally
-    short trace is found
+    short trace is found.
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def trim_event_stream(
         The waveforms to trim
     merge : int, optional
         If not None, merge the waveforms with this method before trimming. See
-        obspy waveforms docs for merge options
+        obspy waveforms docs for merge options.
     copy : bool
         Copy the waveforms before altering it.
     trim_tolerance:

--- a/obsplus/waveforms/utils.py
+++ b/obsplus/waveforms/utils.py
@@ -5,12 +5,12 @@ import copy
 import warnings
 from functools import singledispatch
 from pathlib import Path
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union, List
 
 import numpy as np
 import obspy
 import pandas as pd
-from obspy import Stream, UTCDateTime, Trace
+from obspy import Stream, UTCDateTime
 
 import obsplus
 from obsplus.constants import (
@@ -22,7 +22,7 @@ from obsplus.constants import (
     waveform_request_type,
 )
 from obsplus.interfaces import WaveformClient
-from obsplus.utils import get_nslc_series, _column_contains
+from obsplus.utils import get_nslc_series, filter_index
 
 
 # ---------- trim functions
@@ -174,40 +174,32 @@ def stream_bulk_split(st: Stream, bulk: List[waveform_request_type]) -> List[Str
     -------
     List of traces, each meeting the corresponding request in bulk.
     """
+
+    def build_stream_list(bulks, needs, st):
+        """ Build the stream list and return it. """
+        out = []
+        for bulk, need in zip(bulks, needs):
+            traces = [tr for tr, bo in zip(st, need) if bo]
+            new_st = obspy.Stream(traces)
+            t1 = UTCDateTime(bulk[-2])
+            t2 = UTCDateTime(bulk[-1])
+            new = new_st.slice(starttime=t1, endtime=t2)
+            if new is None or not len(new):
+                out.append(obspy.Stream())
+                continue
+            new.merge(method=1)
+            out.append(new)
+        assert len(out) == len(bulks), "out is not the same len as bulk"
+        return out
+
     # return nothing if empty bulk or stream args
     if not bulk or len(st) == 0:
         return []
 
-    # get dataframe of stream contents
+    # get stream dataframe and determine which bulks need them
     sdf = _stream_data_to_df(st)
-    seed_st = get_nslc_series(sdf)
-    # get dataframe of bulk content
-    bulk_df = pd.DataFrame(bulk, columns=list(NSLC) + ["utc1", "utc2"])
-    bulk_t1 = bulk_df["utc1"].apply(float)
-    bulk_t2 = bulk_df["utc2"].apply(float)
-    seed_bulk = get_nslc_series(bulk_df)
-    # get outer array of time matches
-    is_greater = np.greater.outer(sdf["starttime"].values, bulk_t2)
-    is_less = np.less.outer(sdf["endtime"].values, bulk_t1)
-    is_in_time = ~(is_greater | is_less)
-    # determine if seeds are equal
-    matches_seed = np.equal.outer(seed_st.values, seed_bulk.values)
-    # get a list of needed values
-    needs = np.logical_and(matches_seed, is_in_time)
-    # iterate stream, return output
-    out = []
-    for num, need in enumerate(needs.T):
-        traces = [tr for tr, bo in zip(st, need) if bo]
-        new_st = obspy.Stream(traces)
-        t1, t2 = UTCDateTime(bulk_t1[num]), UTCDateTime(bulk_t2[num])
-        new = new_st.slice(starttime=t1, endtime=t2)
-        if new is None or not len(new):
-            out.append(obspy.Stream())
-            continue
-        new.merge(method=1)
-        out.append(new)
-    assert len(out) == len(bulk), "output is not the same len as stream list"
-    return out
+    needs = [filter_index(sdf, *x) for x in bulk]
+    return build_stream_list(bulk, needs, st)
 
 
 def merge_traces(st: trace_sequence, inplace=False) -> obspy.Stream:

--- a/profiling/profile_json.ipynb
+++ b/profiling/profile_json.ipynb
@@ -122,7 +122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/profiling/profile_stream_bulk_split.ipynb
+++ b/profiling/profile_stream_bulk_split.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Profile stream_bulk_split\n",
+    "\n",
+    "A simple notebook to profile the function `stream_bulk_split` from obsplus.waveforms.utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timeit\n",
+    "from functools import reduce\n",
+    "from operator import add\n",
+    "\n",
+    "import obsplus\n",
+    "import obspy\n",
+    "import pandas as pd\n",
+    "from obsplus.waveforms.utils import stream_bulk_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define params to profile\n",
+    "# num_traces = [3, 6, 12, 30, 60, 90]\n",
+    "# num_bulk = [3, 6, 12, 30]\n",
+    "\n",
+    "\n",
+    "num_traces = [6, 18, 24]\n",
+    "num_bulk = [6, 12, 24]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get stream(s)\n",
+    "stream_dict = {}\n",
+    "for stream_num in num_traces:\n",
+    "    st = reduce(add, [obspy.read() for _ in range(stream_num // 3)])\n",
+    "    stream_dict[stream_num] = st"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st_original = obspy.read()\n",
+    "# get bulk dict\n",
+    "bulk_dict = {}\n",
+    "for bulk_num in num_bulk:\n",
+    "    bulk = []\n",
+    "    for bnum in range(bulk_num // 3):\n",
+    "        sub_bulk = []\n",
+    "        for tr in st_original:\n",
+    "            t1 = tr.stats.starttime + 1\n",
+    "            t2 = tr.stats.endtime + 1\n",
+    "            sub_bulk.append(tr.id.split('.') + [t1, t2])\n",
+    "        bulk.extend(sub_bulk)\n",
+    "    bulk_dict[bulk_num] = bulk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(columns=list(stream_dict), index=list(bulk_dict))\n",
+    "df.columns.name = 'trace_count'\n",
+    "df.index.name = 'bulk_count'\n",
+    "\n",
+    "for tr_num, st in stream_dict.items():\n",
+    "    for bulk_num, bulk in bulk_dict.items():\n",
+    "        print(f'bulk: {bulk_num}, tr_num: {tr_num}')\n",
+    "        assert len(st) == tr_num\n",
+    "        assert len(bulk) == bulk_num\n",
+    "        \n",
+    "        out = %timeit -o stream_bulk_split(st, bulk)\n",
+    "        print('')\n",
+    "        df.loc[bulk_num, tr_num] = out.average\n",
+    "        \n",
+    "#         %timeit stream_bulk_split(st, bulk)\n",
+    "        \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load_ext snakeviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%snakeviz\n",
+    "# stream_bulk_split(st, bulk)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/profiling/profile_wavebank.ipynb
+++ b/profiling/profile_wavebank.ipynb
@@ -28,6 +28,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext snakeviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "test_dir = Path('archive')\n",
     "index_file = test_dir / '.index.h5'\n",
     "\n",
@@ -74,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %timeit index_update()"
+    "%timeit index_update()"
    ]
   },
   {
@@ -92,7 +101,7 @@
    "source": [
     "index = wb.read_index()\n",
     "start = index.starttime.min()\n",
-    "end = start + 48 * 3600 * 2"
+    "end = start + 12 * 3600"
    ]
   },
   {
@@ -110,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "for st in wb.yield_waveforms(starttime=start, endtime=end, duration=3600, overlap=2):\n",
     "    pass"
    ]
@@ -185,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,10 @@ from os.path import basename
 from os.path import join, dirname, abspath, exists
 from pathlib import Path
 
+import numpy as np
 import obspy
 import pytest
 
-import obsplus
 import obsplus.events.utils
 
 # ------------------------- define constants
@@ -128,6 +128,47 @@ station_cache_obj = ObspyCache(INVENTORY_DIRECTORY, obspy.read_inventory)
 # -------------------- collection of test cases
 
 
+class StreamTester:
+    """ A collection of methods for testing waveforms. """
+
+    @staticmethod
+    def streams_almost_equal(st1, st2):
+        """
+        Return True if two streams are almost equal.
+
+        Will only look at default params for stats objects.
+
+        Parameters
+        ----------
+        st1
+            The first stream.
+        st2
+            The second stream.
+        """
+
+        stats_attrs = (
+            "starttime",
+            "endtime",
+            "sampling_rate",
+            "network",
+            "station",
+            "location",
+            "channel",
+        )
+
+        st1, st2 = st1.copy(), st2.copy()
+        st1.sort()
+        st2.sort()
+        for tr1, tr2 in zip(st1, st2):
+            stats1 = {x: tr1.stats[x] for x in stats_attrs}
+            stats2 = {x: tr2.stats[x] for x in stats_attrs}
+            if not stats1 == stats2:
+                return False
+            if not np.all(np.isclose(tr1.data, tr2.data)):
+                return False
+        return True
+
+
 class DataSet(typing.NamedTuple):
     """ A data class for storing info about test cases """
 
@@ -199,6 +240,12 @@ def crandall_bank(crandall_dataset):
 
 
 # ------------------------- session fixtures
+
+
+@pytest.fixture(scope="session")
+def stream_tester():
+    """ return the StreamTester. """
+    return StreamTester
 
 
 @pytest.yield_fixture(scope="module")


### PR DESCRIPTION
This PR does the follow:

1. Makes the `stream_bulk_split` method more efficient by using obsplus' merge rather than obspy's
2. Renames `merge_traces` to `merge_trim_split` to better reflect what the function does; also adds the trim functionality to it.
3. Adds a Testing utility for streams which can be accessed via fixture `stream_tester` fixture.