### PR TITLE
add update time to be passed to update_index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ obsplus master:
   - obsplus.bank
     * Speed up wavebank.get_waveforms_bulk by time-filtering index before
       determining which files to read (see #93).
+    * Update time is now set before reading files to update index (#95).
 
 
 obsplus 0.0.1:


### PR DESCRIPTION
Update time is now determined before reading stream files for indexing. This is important because, for long indexing jobs, files added during the indexing would have modified timestamps before the update_time and would consequently be missed.