### PR TITLE
debug concurrent index updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install -e .
 
 script:
-  - pytest  -v --cov obsplus && pytest --nbval docs/
+  - pytest  -v -s --cov obsplus && pytest --nbval docs/
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install -e .
 
 script:
-  - pytest  -v -s --cov obsplus && pytest --nbval docs/
+  - pytest --cov obsplus && pytest --nbval docs/
 
 after_success:
   - coveralls

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@ obsplus master:
     * Speed up wavebank.get_waveforms_bulk by time-filtering index before
       determining which files to read (see #93).
     * Update time is now set before reading files to update index (#95).
+    * add try/except in read index to alleviate test failures with concurrent
+      updates (see #101).
   - obsplus.conversions
     * Added a preserve_units flag to project and ensured forward compatibility
       with pyproj 2.x.x.

--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -224,11 +224,13 @@ class _IndexCache:
                 self.bank.index_path, self.bank._index_node, where=where, **kwargs
             )
 
-        except ClosedNodeError as e:  # In multiprocessing sometimes
+        except ClosedNodeError as e:
+            # Sometimes in concurrent updates the nodes need time to open/close
             if fail_counts > 10:
                 raise e
+            # Wait a bit and try again (up to 10 times)
             time.sleep(0.1)
-            self._get_index(where, fail_counts=fail_counts + 1, **kwargs)
+            return self._get_index(where, fail_counts=fail_counts + 1, **kwargs)
 
     def clear_cache(self):
         """ removes all cached dataframes. """

--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -224,7 +224,7 @@ class _IndexCache:
                 self.bank.index_path, self.bank._index_node, where=where, **kwargs
             )
 
-        except ClosedNodeError as e:
+        except (ClosedNodeError, TypeError) as e:
             # Sometimes in concurrent updates the nodes need time to open/close
             if fail_counts > 10:
                 raise e

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1233,6 +1233,7 @@ class TestConcurrentUpdateIndex:
         except Exception as e:
             return traceback.format_tb(e.__traceback__)
         else:
+            time.sleep(0.01)
             wbank.read_index()
             return None
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1221,12 +1221,19 @@ class TestConcurrency:
 
     def func(self, wbank):
         """ add new files to the wavebank then update index, return index. """
+        # first write some new files
         path = Path(wbank.bank_path)
         for ind in range(self.new_files):
             st = obspy.read()
             st.write(f"{path / str(ind)}.mseed", "mseed")
-        wbank.update_index()
-        return wbank.read_index()
+        # then try to update index, catch any errors and print them
+        try:
+            wbank.update_index()
+        except Exception as e:
+            traceback.print_tb(e.__traceback__)
+            raise e
+        else:
+            return wbank.read_index()
 
     # fixtures
     @pytest.fixture
@@ -1243,7 +1250,7 @@ class TestConcurrency:
             yield executor
 
     @pytest.fixture
-    def thread_update_index(self, concurrent_bank, thread_pool):
+    def thread_update(self, concurrent_bank, thread_pool):
         """ run a bunch of update index operations in different threads,
         return list of results """
         out = []
@@ -1260,7 +1267,7 @@ class TestConcurrency:
             yield executor
 
     @pytest.fixture
-    def process_update_index(self, concurrent_bank, process_pool):
+    def process_update(self, concurrent_bank, process_pool):
         """ run a bunch of update index operations in different processes,
         return list of results """
         concurrent_bank.update_index()
@@ -1272,24 +1279,28 @@ class TestConcurrency:
         return list(as_completed(out))
 
     # tests
-    def test_index_update_threads(self, thread_update_index):
+    def test_index_update_threads(self, thread_update):
         """ ensure the index updated and the threads didn't kill each
         other """
         # get a list of exceptions that occurred
-        assert len(thread_update_index) == self.worker_count
-        excs = [x.exception() for x in thread_update_index if x.exception() is not None]
-        assert len(excs) == 0
+        assert len(thread_update) == self.worker_count
+        excs = [x.exception() for x in thread_update]
+        excs = [x for x in excs if x is not None]
+        if excs:
+            msg = f"Exceptions were raised by the thread pool:\n {excs}"
+            pytest.fail(msg)
 
-    def test_index_update_processes(self, process_update_index):
+    def test_index_update_processes(self, process_update):
         """
         Ensure the index can be updated in different processes.
         """
-        assert len(process_update_index) == self.worker_count
+        assert len(process_update) == self.worker_count
         # ensure no exceptions were raised
-        excs = [
-            x.exception() for x in process_update_index if x.exception() is not None
-        ]
-        assert len(excs) == 0
+        excs = [x.exception() for x in process_update]
+        excs = [x for x in excs if x is not None]
+        if excs:
+            msg = f"Exceptions were raised by the process pool:\n {excs}"
+            pytest.fail(msg)
 
     def test_file_lock(self, concurrent_bank):
         """ Tests for the file locking mechanism. """


### PR DESCRIPTION
The Travis failures related to the concurrent updates feature of `WaveBank` seem to be showing up more these days. This attempts to bebug the issues.