### PR TITLE
add source to Inventory created by df_to_inventory

### DIFF
--- a/obsplus/stations/utils.py
+++ b/obsplus/stations/utils.py
@@ -99,7 +99,7 @@ def df_to_inventory(df) -> obspy.Inventory:
         kwargs = _get_kwargs(net_df.iloc[0], net_map)
         networks.append(Network(stations=stations, **kwargs))
 
-    return obspy.Inventory(networks=networks)
+    return obspy.Inventory(networks=networks, source=f"ObsPlus_v{obsplus.__version__}")
 
 
 @singledispatch


### PR DESCRIPTION
This corrects a minor bug where `df_to_inventory` fails using older versions of ObsPy because `source` used to be a positional argument for an `Inventory` (this got changed in ObsPy 1.1.1).

As a fix, the source is specified as "ObsPlus_v{version#}".