### PR TITLE
Reduce indexing during initial update_index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+obsplus master:
+  - obsplus.bank
+    * Refactored logic for getting bank progress bars, now can use instances
+      of obsplus.interfaces.ProgressBar to avoid counting files twice
+      and for further customizability (see #106).
+    * Removed min_file_for_bar argument in favor of class attribute of
+      _min_files_for_bar (see #106).
+  - obsplus.interfaces
+    * Added ProgressBar for defining classes compatible with how obsplus
+      uses progress bar, modeled after the ProgressBar class from the
+      progressbar2 library (see #106).
+
 obsplus 0.0.2:
   - obsplus.bank
     * Speed up wavebank.get_waveforms_bulk by time-filtering index before

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -39,6 +39,8 @@ class _Bank(ABC):
     bank_path = ""
     namespace = ""
     index_name = ".index.h5"  # name of index file
+    use_progress_bar = True  # See PR #106 - indexing for progress bar can slow
+    # indexing process down.
     # concurrency handling features
     _lock_file_name = ".~obsplus_hdf5.lock"
     _owns_lock = False

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -19,7 +19,8 @@ from pandas.io.sql import DatabaseError
 
 import obsplus
 from obsplus.exceptions import BankDoesNotExistError, BankIndexLockError
-from obsplus.utils import iter_files
+from obsplus.interfaces import ProgressBar
+from obsplus.utils import iter_files, get_progressbar
 
 
 BankType = TypeVar("BankType", bound="_Bank")
@@ -39,7 +40,6 @@ class _Bank(ABC):
     bank_path = ""
     namespace = ""
     index_name = ".index.h5"  # name of index file
-    use_progress_bar = True  # See PR #106 - indexing for progress bar can slow
     # indexing process down.
     # concurrency handling features
     _lock_file_name = ".~obsplus_hdf5.lock"
@@ -52,7 +52,9 @@ class _Bank(ABC):
     # the minimum obsplus version. If not met delete index and re-index
     # bump when database schema change.
     _min_version = "0.0.0"
+    # status bar attributes
     _bar_update_interval = 50  # number of files before updating bar
+    _min_files_for_bar = 100  # min number of files before using bar enabled
 
     @abstractmethod
     def read_index(self, **kwargs) -> pd.DataFrame:
@@ -226,3 +228,33 @@ class _Bank(ABC):
             with suppress(FileNotFoundError):
                 os.unlink(self.lock_file_path)
             self._owns_lock = False
+
+    def get_progress_bar(self, bar=None) -> Optional[ProgressBar]:
+        """
+        Return a progress bar instance based on bar parameter.
+
+        If bar is False, return None.
+        If bar is None return default Bar
+        If bar is a subclass of ProgressBar, init class and set max_values.
+        If bar is an instance of ProgressBar, return it.
+        """
+        # conditions to bail out early
+        if bar is False:  # False indicates no bar is to be used
+            return None
+        elif isinstance(bar, ProgressBar):  # bar is already instantiated
+            return bar
+        # next, count number of files
+        num_files = sum([1 for _ in self._unindexed_file_iterator()])
+        if num_files < self._min_files_for_bar:  # not enough files to use bar
+            return None
+        # instantiate bar and return
+        print(f"updating or creating event index for {self.bank_path}")
+        kwargs = {"min_value": self._min_files_for_bar, "max_value": num_files}
+        # an instance should be init'ed
+        if isinstance(bar, type) and issubclass(bar, ProgressBar):
+            return bar(**kwargs)
+        elif bar is None:
+            return get_progressbar(**kwargs)
+        else:
+            msg = f"{bar} is not a valid input for get_progress_bar"
+            raise ValueError(msg)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -31,6 +31,7 @@ from obsplus.constants import (
     EVENT_NAME_STRUCTURE,
     EVENT_DTYPES,
     get_events_parameters,
+    bar_paramter_description,
 )
 from obsplus.exceptions import BankDoesNotExistError
 from obsplus.utils import (
@@ -39,6 +40,7 @@ from obsplus.utils import (
     thread_lock_function,
     compose_docstring,
 )
+from obsplus.interfaces import ProgressBar
 
 # --- define static types
 
@@ -99,6 +101,7 @@ class EventBank(_Bank):
 
     namespace = "/events"
     index_name = ".index.db"  # name of index file
+    _min_files_for_bar = 50
 
     def __init__(
         self,
@@ -180,31 +183,17 @@ class EventBank(_Bank):
         return df
 
     @thread_lock_function()
-    def update_index(
-        self, bar: Optional = None, min_files_for_bar: int = 100
-    ) -> "EventBank":
+    @compose_docstring(bar_paramter_description=bar_paramter_description)
+    def update_index(self, bar: Optional[ProgressBar] = None) -> "EventBank":
         """
         Iterate files in bank and add any modified since last update to index.
 
         Parameters
         ----------
-        bar
-            Any class that has an `update` and `finish` method, should behave
-            the same as the progressbar.ProgressBar class. This method provides
-            a way to override the default progress bar but is rarely needed.
-        min_files_for_bar
-            Minimum number of un-indexed files required for displaying the
-            progress bar.
+        {bar_parameter_description}
         """
-        self._enforce_min_version()
-        if self.use_progress_bar:
-            num_files = sum([1 for _ in self._unindexed_file_iterator()])
-        else:
-            num_files = -1
-        if num_files >= min_files_for_bar:
-            print(f"updating or creating event index for {self.bank_path}")
-        kwargs = {"min_value": min_files_for_bar, "max_value": num_files}
-        bar = get_progressbar(**kwargs) if bar is None else bar(**kwargs)
+        self._enforce_min_version()  # delete index if schema has changed
+        bar = self.get_progress_bar(bar)  # get ProgressBar or None
         # loop over un-index files and update
         events, update_time, paths = [], [], []
         for num, fi in enumerate(self._unindexed_file_iterator()):
@@ -216,15 +205,15 @@ class EventBank(_Bank):
                 update_time.append(getmtime(fi))
                 paths.append(fi.replace(self.bank_path, ""))
             # update progress bar
-            if bar and num % self._bar_update_interval == 0:
+            if bar is not None and num % self._bar_update_interval == 0:
                 bar.update(num)
-        getattr(bar, "finish", lambda: None)()  # call finish if it exists
         # add new events to database
         df = obsplus.events.pd._default_cat_to_df(obspy.Catalog(events=events))
         df["updated"] = update_time
         df["path"] = paths
         if len(df):
             self._write_update(self._clean_dataframe(df))
+        getattr(bar, "finish", lambda: None)()  # call finish if bar exists
         return self
 
     def _clean_dataframe(self, df: pd.DataFrame):

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -181,10 +181,7 @@ class EventBank(_Bank):
 
     @thread_lock_function()
     def update_index(
-        self,
-        bar: Optional = None,
-        min_files_for_bar: int = 100,
-        num_files: Optional[int] = None,
+        self, bar: Optional = None, min_files_for_bar: int = 100
     ) -> "EventBank":
         """
         Iterate files in bank and add any modified since last update to index.
@@ -198,15 +195,12 @@ class EventBank(_Bank):
         min_files_for_bar
             Minimum number of un-indexed files required for displaying the
             progress bar.
-        num_files
-            The number of files to be indexed - used only for bar. If not set
-            the number of files will be counted. For large databases this can
-            be a large time-sink, so you can set num_files to something
-            representative.
         """
         self._enforce_min_version()
-        if num_files is None:
+        if self.use_progress_bar:
             num_files = sum([1 for _ in self._unindexed_file_iterator()])
+        else:
+            num_files = -1
         if num_files >= min_files_for_bar:
             print(f"updating or creating event index for {self.bank_path}")
         kwargs = {"min_value": min_files_for_bar, "max_value": num_files}

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -546,3 +546,16 @@ contributor: str, optional
     Limit to events contributed by a specified contributor.
 updatedafter: obspy.UTCDateTime or valid input to such, optional
     Limit to events updated after the specified time."""
+
+# the description for the parameter 'bar' in the bank `update_index` methods.
+bar_paramter_description = """
+bar
+    This parameter controls if a progress bar will be used for this
+    function call. Its behavior is dependent on the `bar` parameter:
+        False - Dont use a progress bar
+        None - Use the default progress bar
+        ProgressBar - a custom implementation of progress bar is used.
+        
+    If a custom progress bar is to be used, it must have an `update`
+    and `finish` method.
+"""

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -4,7 +4,7 @@ Some common interfaces for event/client types.
 Note: These are used instead of the ones in obspy.clients.base so the subclass
 hooks can be used.
 """
-from abc import ABC
+from abc import ABC, abstractmethod
 import obspy
 
 
@@ -54,6 +54,22 @@ class BankType(ABC, _MethodChecker):
     """ an object that looks like a bank """
 
     required_methods = {"read_index"}
+
+
+class ProgressBar(ABC, _MethodChecker):
+    """
+    A class that behaves like the progressbar2.ProgressBar class.
+    """
+
+    required_methods: set = {"update", "finish"}
+
+    @abstractmethod
+    def update(self, value=None, force=False, **kwargs):
+        """ Called when updating the progress bar. """
+
+    @abstractmethod
+    def finish(self, **kwargs):
+        """ Puts the progress bar in the finished state. """
 
 
 # register virtual subclasses

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -757,27 +757,14 @@ def iter_files(path, ext=None, mtime=None, skip_hidden=True):
     -------
 
     """
-    if mtime is None:
-        # mtime doesn't need to be checked for None for every-file - this can
-        # be slow for large unindexed databases.
-        for entry in os.scandir(path):
-            if entry.is_file() and (ext is None or entry.name.endswith(ext)):
+    for entry in os.scandir(path):
+        if entry.is_file() and (ext is None or entry.name.endswith(ext)):
+            if mtime is None or entry.stat().st_mtime >= mtime:
                 if entry.name[0] != "." or not skip_hidden:
                     yield entry.path
-            elif entry.is_dir():
-                yield from iter_files(
-                    entry.path, ext=ext, mtime=mtime, skip_hidden=skip_hidden
-                )
-    else:
-        for entry in os.scandir(path):
-            if entry.is_file() and (ext is None or entry.name.endswith(ext)):
-                if entry.stat().st_mtime >= mtime:
-                    if entry.name[0] != "." or not skip_hidden:
-                        yield entry.path
-            elif entry.is_dir():
-                yield from iter_files(
-                    entry.path, ext=ext, mtime=mtime, skip_hidden=skip_hidden
-                )
+        elif entry.is_dir():
+            yield from iter_files(entry.path, ext=ext, mtime=mtime,
+                                  skip_hidden=skip_hidden)
 
 
 def get_distance_df(

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -763,8 +763,9 @@ def iter_files(path, ext=None, mtime=None, skip_hidden=True):
                 if entry.name[0] != "." or not skip_hidden:
                     yield entry.path
         elif entry.is_dir():
-            yield from iter_files(entry.path, ext=ext, mtime=mtime,
-                                  skip_hidden=skip_hidden)
+            yield from iter_files(
+                entry.path, ext=ext, mtime=mtime, skip_hidden=skip_hidden
+            )
 
 
 def get_distance_df(

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -757,13 +757,27 @@ def iter_files(path, ext=None, mtime=None, skip_hidden=True):
     -------
 
     """
-    for entry in os.scandir(path):
-        if entry.is_file() and (ext is None or entry.name.endswith(ext)):
-            if mtime is None or entry.stat().st_mtime >= mtime:
+    if mtime is None:
+        # mtime doesn't need to be checked for None for every-file - this can
+        # be slow for large unindexed databases.
+        for entry in os.scandir(path):
+            if entry.is_file() and (ext is None or entry.name.endswith(ext)):
                 if entry.name[0] != "." or not skip_hidden:
                     yield entry.path
-        elif entry.is_dir():
-            yield from iter_files(entry.path, ext=ext, mtime=mtime)
+            elif entry.is_dir():
+                yield from iter_files(
+                    entry.path, ext=ext, mtime=mtime, skip_hidden=skip_hidden
+                )
+    else:
+        for entry in os.scandir(path):
+            if entry.is_file() and (ext is None or entry.name.endswith(ext)):
+                if entry.stat().st_mtime >= mtime:
+                    if entry.name[0] != "." or not skip_hidden:
+                        yield entry.path
+            elif entry.is_dir():
+                yield from iter_files(
+                    entry.path, ext=ext, mtime=mtime, skip_hidden=skip_hidden
+                )
 
 
 def get_distance_df(

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -1,8 +1,10 @@
 """
 tests for event wavebank
 """
-from pathlib import Path
 import os
+import sys
+from pathlib import Path
+from io import StringIO
 
 import obspy
 import obspy.core.event as ev
@@ -125,29 +127,6 @@ class TestBankBasics:
         cat = obspy.read_events()
         df = ebank_with_bad_files.read_index()
         assert len(cat) == len(df)
-
-    def test_custom_bar(self, ebank_with_bad_files):
-        """ ensure a custom update bar function works. """
-
-        class Bar:
-            called = False
-
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def update(self, num):
-                self.__class__.called = True
-
-            def finish(self):
-                pass
-
-        # set the interval to 1 to ensure it gets called
-        ebank_with_bad_files._bar_update_interval = 1
-        # remove old index, update with custom bar function
-        os.remove(ebank_with_bad_files.index_path)
-        with pytest.warns(UserWarning):
-            ebank_with_bad_files.update_index(bar=Bar, min_files_for_bar=1)
-        assert Bar.called
 
     def test_service_version(self, bing_ebank):
         """ The get_service_version method should return obsplus version """
@@ -334,3 +313,91 @@ class TestPutEvents:
         assert len(index1) == len(index2)
         index_lat = index2.loc[index2.index == str(eve.resource_id), "latitude"]
         assert index_lat.iloc[0] == new_lat
+
+
+class TestProgressBar:
+    """ Tests for the progress bar functionality of banks. """
+
+    @pytest.fixture
+    def custom_bar(self):
+        """ return a custom bar implementation. """
+
+        class Bar:
+            called = False
+
+            def __init__(self, *args, **kwargs):
+                self.finished = False
+
+            def update(self, num):
+                self.__class__.called = True
+
+            def finish(self):
+                self.finished = True
+                pass
+
+        return Bar
+
+    @pytest.fixture()
+    def bar_ebank(self, ebank, monkeypatch):
+        """ return an event bank specifically for testing ProgressBar. """
+        # set the interval and min files to 1 to ensure bar gets called
+        monkeypatch.setattr(ebank, "_bar_update_interval", 1)
+        monkeypatch.setattr(ebank, "_min_files_for_bar", 1)
+        # move the index to make sure there are files to update
+        index_path = Path(ebank.index_path)
+        if index_path.exists():
+            os.remove(index_path)
+        return ebank
+
+    @pytest.fixture()
+    def bar_ebank_bad_file(self, bar_ebank):
+        """ Add a waveform file to ensure ProgressBar doesnt choke. """
+        path = Path(bar_ebank.bank_path)
+        st = obspy.read()
+        st.write(str(path / "waveform.xml"), "mseed")
+        return bar_ebank
+
+    def test_custom_bar_class(self, bar_ebank, custom_bar):
+        """ Ensure a custom update bar function works. """
+        bar_ebank.update_index(bar=custom_bar)
+        assert custom_bar.called
+
+    def test_custom_bar_instances(self, bar_ebank, custom_bar):
+        """ Ensure passing an instance to bar will simply use instance. """
+        bar = custom_bar()
+        assert not bar.finished
+        bar_ebank.update_index(bar=bar)
+        assert bar.finished
+
+    def test_bad_file_raises_warning(self, bar_ebank_bad_file, custom_bar):
+        """ Ensure a bad files raises warning but doesn't kill progress. """
+        with pytest.warns(UserWarning):
+            bar_ebank_bad_file.update_index(custom_bar)
+
+    def test_false_disables_bar(self, bar_ebank, monkeypatch):
+        """ Passing False for bar argument should disable it. """
+        # we ensure the default bar isnt by monkey patching the util to get it
+        state = {"called": False}
+
+        def new_get_bar(*args, **kwargs):
+            state["called"] = True
+            obsplus.utils.get_progressbar(*args, **kwargs)
+
+        monkeypatch.setattr(obsplus.utils, "get_progressbar", new_get_bar)
+
+        bar_ebank.update_index(bar=False)
+        assert state["called"] is False
+
+    def test_bad_value_raises(self, bar_ebank):
+        """ Passing an unsupported value to bar should raise. """
+        with pytest.raises(ValueError):
+            bar_ebank.update_index(bar="unsupported")
+
+    def test_update_bar_default(self, bar_ebank, monkeypatch):
+        """ Ensure the default progress bar shows up. """
+        stringio = StringIO()
+        monkeypatch.setattr(sys, "stdout", stringio)
+        bar_ebank.update_index()
+        stringio.seek(0)
+        out = stringio.read()
+        assert "updating or creating" in out

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -648,39 +648,6 @@ class TestGetWaveforms:
         assert len(st) == 3
 
 
-class TestUpdateBar:
-    """ tests for the update bar and hook """
-
-    class Bar:
-        def __init__(self, max_value=100, min_value=None):
-            self.out = dict(count=0)
-            self.max = max
-
-        def update(self, current):
-            self.out["count"] += 1
-
-        def finish(self):
-            pass
-
-        def __call__(self, *args, **kwargs):
-            return self
-
-    def test_update_hook(self, ta_bank_no_index):
-        """ test custom bar works """
-        bar = self.Bar()
-        ta_bank_no_index.update_index(bar=bar, min_files_for_bar=0)
-        assert bar.out["count"] > 0
-
-    def test_update_bar_default(self, ta_bank_no_index, monkeypatch):
-        """ ensure the default progress bar shows up. """
-        stringio = StringIO()
-        monkeypatch.setattr(sys, "stdout", stringio)
-        ta_bank_no_index.update_index(min_files_for_bar=0)
-        stringio.seek(0)
-        out = stringio.read()
-        assert "updating or creating" in out
-
-
 class TestGetBulkWaveforms:
     """ tests for pulling multiple waveforms using get_bulk_waveforms """
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -4,13 +4,11 @@ import glob
 import os
 import pathlib
 import shutil
-import sys
 import tempfile
 import time
-import types
 import traceback
+import types
 from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
-from io import StringIO
 from os.path import join
 from pathlib import Path
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -4,9 +4,10 @@ Ensure the interface isinstance and issubclass methods work
 import obspy
 import pytest
 from obspy.clients.fdsn.client import Client, FDSNException
+from progressbar import ProgressBar as ProgBar
 
 from obsplus import EventBank, WaveBank
-from obsplus.interfaces import EventClient, WaveformClient, StationClient
+from obsplus.interfaces import EventClient, WaveformClient, StationClient, ProgressBar
 
 
 # fixtures
@@ -78,3 +79,36 @@ class TestStationClient:
         inv = obspy.read_inventory()
         assert isinstance(inv, StationClient)
         assert issubclass(obspy.Inventory, StationClient)
+
+
+class TestBar:
+    """ Tests the progressbar interface. """
+
+    def test_progressbar_isinstance(self):
+        """ Ensure the ProgressBar2 ProgressBar is an instance. """
+        assert issubclass(ProgBar, ProgressBar)
+
+    def test_custom_progress_bar(self):
+        """ Ensure custom progress bar works as well. """
+
+        class MyBar:
+            def update(self, num):
+                pass
+
+            def finish(self):
+                pass
+
+        assert issubclass(MyBar, ProgressBar)
+        assert isinstance(MyBar(), ProgressBar)
+
+    def test_malformed_progress_bar(self):
+        """
+        Ensure a ProgressBar implementation missing methods is not subclass.
+        """
+
+        class MyBadBar:
+            def update(self, num):
+                pass
+
+        assert not issubclass(MyBadBar, ProgressBar)
+        assert not isinstance(MyBadBar(), ProgressBar)


### PR DESCRIPTION
`EventBank.update_index` iterates through the directory structure twice, once to count the number of files and the second to generate the index. For large databases the iteration can be a large time-sink.  In this PR an optional argument of `num_files` is added as a work-around to stop the initial iteration and get straight into the bulk of the work. This is a slightly clumsy way to do this and I'm very open to other better thought out options.

It also fixes a minor typo in the doc-string, and passes `skip_hidden` through the iterator.

Annoyingly I ran black after I added and the black patch din't come through - extra commit to come.

Just as a note: obsplus is cool. I really like the type hinting and seeing nice code. Good job. I'm excited to use this for database management for real-time matched-filter detection. Thank you @d-chambers 