### PR TITLE
Concurrent banks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,8 @@ obsplus master:
       _min_files_for_bar (see #106).
     * Add support for circular searches on EventBank (see #110).
     * Removed concurrent update features for WaveBank (see #117).
+    * Add support for using concurrent.futures Executors to speed up indexing
+      and reading files (see #108).
   - obsplus.interfaces
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager, suppress
 from os.path import join
 from pathlib import Path
 from typing import Optional, TypeVar
+from obsplus.constants import CPU_COUNT
 
 import gc
 import numpy as np
@@ -213,6 +214,20 @@ class _Bank(ABC):
         else:
             msg = f"{bar} is not a valid input for get_progress_bar"
             raise ValueError(msg)
+
+    @property
+    def _max_workers(self):
+        """
+        Return the max number of workers allowed by the executor.
+
+        If the Executor has no attribute `_max_workers` use the number of
+        CPUs instead. If there is no executor assigned to bank instance
+        return 1.
+        """
+        executor = getattr(self, "executor", None)
+        if executor is not None:
+            return getattr(executor, "_max_workers", CPU_COUNT)
+        return 1
 
     def _map(self, func, args, chunksize=None):
         """

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -21,6 +21,7 @@ import obsplus
 from obsplus.exceptions import BankDoesNotExistError, BankIndexLockError
 from obsplus.interfaces import ProgressBar
 from obsplus.utils import iter_files, get_progressbar
+from obsplus.constants import CPU_COUNT
 
 
 BankType = TypeVar("BankType", bound="_Bank")
@@ -191,12 +192,12 @@ class _Bank(ABC):
             msg = f"{bar} is not a valid input for get_progress_bar"
             raise ValueError(msg)
 
-    def _map(self, func, args):
+    def _map(self, func, args, chunksize=None):
         """
         Map the args to function, using executor if defined else performed
         in serial.
         """
         if self.executor is not None:
-            return self.executor.map(func, args)
+            return self.executor.map(func, args, chunksize=chunksize)
         else:
             return (func(x) for x in args)

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -1,7 +1,6 @@
 """
 Bank ABC
 """
-import gc
 import os
 import threading
 import time
@@ -12,6 +11,7 @@ from os.path import join
 from pathlib import Path
 from typing import Optional, TypeVar
 
+import gc
 import numpy as np
 import pandas as pd
 import tables
@@ -21,8 +21,6 @@ import obsplus
 from obsplus.exceptions import BankDoesNotExistError, BankIndexLockError
 from obsplus.interfaces import ProgressBar
 from obsplus.utils import iter_files, get_progressbar
-from obsplus.constants import CPU_COUNT
-
 
 BankType = TypeVar("BankType", bound="_Bank")
 
@@ -126,8 +124,8 @@ class _Bank(ABC):
                 warnings.warn(msg)
                 os.remove(self.index_path)
 
-    def _unindexed_file_iterator(self):
-        """ return an iterator of potential unindexed waveform files """
+    def _unindexed_iterator(self):
+        """ return an iterator of potential unindexed files """
         # get mtime, subtract a bit to avoid odd bugs
         mtime = None
         last_updated = self.last_updated  # this needs db so only call once
@@ -135,6 +133,30 @@ class _Bank(ABC):
             mtime = last_updated - 0.001
         # return file iterator
         return iter_files(self.bank_path, ext=self.ext, mtime=mtime)
+
+    def _measured_unindexed_iterator(self, bar: Optional[ProgressBar] = None):
+        """
+        A generator to yield un-indexed files and update progress bar.
+
+        Parameters
+        ----------
+        bar
+            Any object with an update method.
+
+        Returns
+        -------
+
+        """
+        # get progress bar
+        bar = self.get_progress_bar(bar)
+        # get the iterator
+        for num, path in enumerate(self._unindexed_iterator()):
+            # update bar if count is in update interval
+            if bar is not None and num % self._bar_update_interval == 0:
+                bar.update(num)
+            yield path
+        # finish progress bar
+        getattr(bar, "finish", lambda: None)()  # call finish if bar exists
 
     def _make_meta_table(self):
         """ get a dataframe of meta info """
@@ -177,7 +199,7 @@ class _Bank(ABC):
         elif isinstance(bar, ProgressBar):  # bar is already instantiated
             return bar
         # next, count number of files
-        num_files = sum([1 for _ in self._unindexed_file_iterator()])
+        num_files = sum([1 for _ in self._unindexed_iterator()])
         if num_files < self._min_files_for_bar:  # not enough files to use bar
             return None
         # instantiate bar and return
@@ -194,7 +216,7 @@ class _Bank(ABC):
 
     def _map(self, func, args, chunksize=None):
         """
-        Map the args to function, using executor if defined else performed
+        Map the args to function, using executor if defined else perform
         in serial.
         """
         if self.executor is not None:

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -22,6 +22,7 @@ import obsplus
 from obsplus.exceptions import BankDoesNotExistError, BankIndexLockError
 from obsplus.interfaces import ProgressBar
 from obsplus.utils import iter_files, get_progressbar
+from obsplus.constants import CPU_COUNT
 
 BankType = TypeVar("BankType", bound="_Bank")
 

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -40,6 +40,7 @@ class _Bank(ABC):
     bank_path = ""
     namespace = ""
     index_name = ".index.h5"  # name of index file
+    executor = None  # an executor for using parallelism
     # optional str defining the directory structure and file name schemes
     path_structure = None
     name_structure = None
@@ -49,6 +50,7 @@ class _Bank(ABC):
     # status bar attributes
     _bar_update_interval = 50  # number of files before updating bar
     _min_files_for_bar = 100  # min number of files before using bar enabled
+    _read_func: callable  # function for reading datatype
 
     @abstractmethod
     def read_index(self, **kwargs) -> pd.DataFrame:
@@ -188,3 +190,13 @@ class _Bank(ABC):
         else:
             msg = f"{bar} is not a valid input for get_progress_bar"
             raise ValueError(msg)
+
+    def _map(self, func, args):
+        """
+        Map the args to function, using executor if defined else performed
+        in serial.
+        """
+        if self.executor is not None:
+            return self.executor.map(func, args)
+        else:
+            return (func(x) for x in args)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -34,7 +34,6 @@ from obsplus.constants import (
     EVENT_DTYPES,
     get_events_parameters,
     bar_paramter_description,
-    CPU_COUNT,
 )
 from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.exceptions import BankDoesNotExistError
@@ -294,7 +293,7 @@ class EventBank(_Bank):
         """
         paths = self.bank_path + self.read_index(columns="path", **kwargs).path
         read_func = partial(_try_read_catalog, format=self.format)
-        kwargs = dict(chunksize=len(paths) // CPU_COUNT)
+        kwargs = dict(chunksize=len(paths) // self._max_workers)
         try:
             return reduce(add, self._map(read_func, paths.values, **kwargs))
         except TypeError:  # empty events

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -4,7 +4,7 @@ Class for interacting with events on a filesystem.
 
 import time
 import warnings
-from functools import reduce
+from functools import reduce, partial
 from operator import add
 from os.path import exists
 from os.path import getmtime, abspath
@@ -25,6 +25,7 @@ from obsplus.bank.utils import (
     _read_table,
     _get_tables,
     _drop_rows,
+    _try_read_catalog,
 )
 from obsplus.constants import (
     EVENT_PATH_STRUCTURE,
@@ -45,11 +46,11 @@ COLUMN_TYPES = dict(EVENT_DTYPES)
 COLUMN_TYPES.pop("stations", None)
 COLUMN_TYPES["path"] = str
 STR_COLUMNS = {i for i, v in COLUMN_TYPES.items() if issubclass(v, str)}
+INT_COLUMNS = {i for i, v in COLUMN_TYPES.items() if v is int}
 
 # unsupported query options
 
 UNSUPPORTED_QUERY_OPTIONS = set()
-
 
 # int_cols = {key for key, val in column_types.items() if val is int}
 
@@ -174,17 +175,12 @@ class EventBank(_Bank):
                 df = _read_table(self._index_node, con, **kwargs)
             except pd.io.sql.DatabaseError:  # empty or no db, return empty index
                 df = pd.DataFrame(columns=list(COLUMN_TYPES))
-        # coerce datatypes
-        dtype = {i: COLUMN_TYPES[i] for i in set(COLUMN_TYPES) & set(df.columns)}
-        df = df.astype(dtype=dtype)
-        # replace "None" with None on str columns
-        str_cols = STR_COLUMNS & set(df.columns)
-        df.loc[:, str_cols] = df.loc[:, str_cols].replace(["None"], [None])
+        df = self._prepare_dataframe(df)
         if len(circular_kwargs) >= 3:
             # Requires at least latitude, longitude and min or max radius
             circular_ids = _get_ids(df, circular_kwargs)
             df = df[df.event_id.isin(circular_ids)]
-        return df.set_index("event_id")
+        return df
 
     @compose_docstring(bar_paramter_description=bar_paramter_description)
     def update_index(self, bar: Optional[ProgressBar] = None) -> "EventBank":
@@ -200,7 +196,7 @@ class EventBank(_Bank):
         # loop over un-index files and update
         events, update_time, paths = [], [], []
         for num, fi in enumerate(self._unindexed_file_iterator()):
-            cat = try_read_catalog(fi, format=self.format)
+            cat = _try_read_catalog(fi, format=self.format)
             if cat is None:
                 continue
             for event in cat:
@@ -215,26 +211,33 @@ class EventBank(_Bank):
         df["updated"] = update_time
         df["path"] = paths
         if len(df):
-            self._write_update(self._clean_dataframe(df))
+            self._write_update(self._prepare_dataframe(df))
         getattr(bar, "finish", lambda: None)()  # call finish if bar exists
         return self
 
-    def _clean_dataframe(self, df: pd.DataFrame):
-        """ clean the dataframe by casting add dtypes """
+    def _prepare_dataframe(self, df: pd.DataFrame):
+        """
+        Fill missing values and casting data types.
+        """
+        # replace "None" with empty string for str columns
+        str_cols = STR_COLUMNS & set(df.columns)
+        df.loc[:, str_cols] = df.loc[:, str_cols].replace(["None"], [""])
         # fill dummy int values
-        for row, dtype in COLUMN_TYPES.items():
-            if dtype is int:
-                df[row] = df[row].fillna(-999)
-        # cast types and set index
-        df = df.astype(COLUMN_TYPES)[list(COLUMN_TYPES)]
-        return df.set_index("event_id")
+        int_cols = INT_COLUMNS & set(df.columns)
+        df.loc[:, int_cols] = df.loc[:, int_cols].fillna(-999)
+        # get expected datatypes
+        dtype = {i: COLUMN_TYPES[i] for i in set(COLUMN_TYPES) & set(df.columns)}
+        # order columns, set types, reset index
+        return df[list(dtype)].astype(dtype=dtype).reset_index(drop=True)
 
     def _write_update(self, df: pd.DataFrame):
         """ convert updates to dataframe, then append to index table """
         # read in dataframe and cast to correct types
         assert not df.duplicated().any(), "update index has duplicate entries"
 
-        current = self.read_index(event_id=set(df.index))
+        # set both dfs to use index of event_id
+        df = df.set_index("event_id")
+        current = self.read_index(event_id=set(df.index)).set_index("event_id")
         indicies_to_update = set(current.index) & set(df.index)
 
         # populate index store and update metadata
@@ -275,14 +278,10 @@ class EventBank(_Bank):
         ----------
         {get_events_params}
         """
-        # Needs to read in latitude and longitude to support circular queries.
-        paths = (
-            self.bank_path
-            + self.read_index(columns=["path", "latitude", "longitude"], **kwargs).path
-        )
-        cats = (obspy.read_events(x) for x in paths)
+        read_func = partial(_try_read_catalog, format=self.format)
+        paths = self.bank_path + self.read_index(columns="path", **kwargs).path
         try:
-            return reduce(add, cats)
+            return reduce(add, self._map(read_func, paths.values))
         except TypeError:  # empty events
             return obspy.Catalog()
 
@@ -305,11 +304,10 @@ class EventBank(_Bank):
         events = [catalog] if isinstance(catalog, ev.Event) else catalog
         # get dataframe of current event info, if they exists
         event_ids = [str(x.resource_id) for x in events]
-        df = self.read_index(event_id=event_ids)
-        index = set(df.index)
+        df = self.read_index(event_id=event_ids).set_index("event_id")
         for event in events:
             rid = str(event.resource_id)
-            if rid in index:  # event needs to be updated
+            if rid in df.index:  # event needs to be updated
                 path = self.bank_path + df.loc[rid, "path"]
                 assert exists(path)
                 event.write(path, self.format)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -199,6 +199,7 @@ class EventBank(_Bank):
         ----------
         {bar_parameter_description}
         """
+
         def func(path):
             """ Function to yield events, update_time and paths. """
             cat = _try_read_catalog(path, format=self.format)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -53,7 +53,6 @@ INT_COLUMNS = {i for i, v in COLUMN_TYPES.items() if v is int}
 
 UNSUPPORTED_QUERY_OPTIONS = set()
 
-
 # int_cols = {key for key, val in column_types.items() if val is int}
 
 
@@ -199,8 +198,6 @@ class EventBank(_Bank):
         ----------
         {bar_parameter_description}
         """
-        self._enforce_min_version()  # delete index if schema has changed
-
         def func(path):
             """ Function to yield events, update_time and paths. """
             cat = _try_read_catalog(path, format=self.format)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -4,6 +4,7 @@ Class for interacting with events on a filesystem.
 
 import time
 import warnings
+from concurrent.futures import Executor
 from functools import reduce, partial
 from operator import add
 from os.path import exists
@@ -92,10 +93,14 @@ class EventBank(_Bank):
     ext
         The extension on the files. Can be used to avoid parsing non-event
         files.
-    cache_size : int
+    cache_size
         The number of queries to store. Avoids having to read the index of
         the database multiple times for queries involving the same start and
         end times.
+    executor
+        An executor with the same interface as concurrent.futures.Executor,
+        the map method of the executor will be used for reading files and
+        updating indices.
     """
 
     namespace = "/events"
@@ -110,6 +115,7 @@ class EventBank(_Bank):
         cache_size: int = 5,
         format="quakeml",
         ext=".xml",
+        executor: Optional[Executor] = None,
     ):
         """ Initialize an instance. """
         if isinstance(base_path, EventBank):
@@ -124,6 +130,7 @@ class EventBank(_Bank):
         self.path_structure = ps
         ns = name_structure or self._name_structure or EVENT_NAME_STRUCTURE
         self.name_structure = ns
+        self.executor = executor
         # initialize cache
         self._index_cache = _IndexCache(self, cache_size=cache_size)
 

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -34,6 +34,7 @@ from obsplus.constants import (
     EVENT_DTYPES,
     get_events_parameters,
     bar_paramter_description,
+    CPU_COUNT,
 )
 from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.exceptions import BankDoesNotExistError
@@ -52,6 +53,7 @@ INT_COLUMNS = {i for i, v in COLUMN_TYPES.items() if v is int}
 # unsupported query options
 
 UNSUPPORTED_QUERY_OPTIONS = set()
+
 
 # int_cols = {key for key, val in column_types.items() if val is int}
 
@@ -205,6 +207,7 @@ class EventBank(_Bank):
             path = path.replace(self.bank_path, "")
             return cat, update_time, path
 
+        self._enforce_min_version()  # delete index if schema has changed
         # create iterator  and lists for storing output
         update_time = time.time()
         iterator = self._measured_unindexed_iterator(bar)

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -34,7 +34,6 @@ from obsplus.constants import (
     EVENT_DTYPES,
     get_events_parameters,
     bar_paramter_description,
-    CPU_COUNT,
 )
 from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.exceptions import BankDoesNotExistError

--- a/obsplus/bank/utils.py
+++ b/obsplus/bank/utils.py
@@ -397,6 +397,19 @@ def _try_read_stream(stream_path, format=None, **kwargs):
     return None
 
 
+def _try_read_catalog(catalog_path, **kwargs):
+    """ Try to read a events from file, if it raises return None """
+    read = READ_DICT.get(kwargs.pop("format", None), obspy.read_events)
+    try:
+        cat = read(catalog_path, **kwargs)
+    except Exception:
+        warnings.warn(f"obspy failed to read {catalog_path}")
+    else:
+        if cat is not None and len(cat):
+            return cat
+    return None
+
+
 @singledispatch
 def get_inventory(inventory: Union[str, Inventory]):
     """

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -35,6 +35,7 @@ from obsplus.constants import (
     utc_time_type,
     get_waveforms_parameters,
     bar_paramter_description,
+    CPU_COUNT,
 )
 from obsplus.utils import (
     compose_docstring,

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -35,7 +35,6 @@ from obsplus.constants import (
     utc_time_type,
     get_waveforms_parameters,
     bar_paramter_description,
-    CPU_COUNT,
 )
 from obsplus.utils import (
     compose_docstring,
@@ -666,7 +665,8 @@ class WaveBank(_Bank):
         func = partial(_try_read_stream, **kwargs)
 
         stt = obspy.Stream()
-        for st in self._map(func, files, chunksize=len(files) // CPU_COUNT):
+        chunksize = len(files) / self._max_workers
+        for st in self._map(func, files, chunksize=chunksize):
             if st is not None:
                 stt += st
         # sort out nullish nslc codes

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -35,7 +35,6 @@ from obsplus.constants import (
     utc_time_type,
     get_waveforms_parameters,
     bar_paramter_description,
-    CPU_COUNT,
 )
 from obsplus.utils import (
     compose_docstring,

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -2,6 +2,7 @@
 Constants used throughout obsplus
 """
 import concurrent.futures
+from os import cpu_count
 from collections import OrderedDict
 from pathlib import Path
 from typing import (
@@ -311,6 +312,9 @@ SMALL_UTC = obspy.UTCDateTime("1970-01-01")
 # path to where obsplus datasets are stored by default
 OPSDATA_PATH = Path().home() / "opsdata"
 
+# Number of cores
+CPU_COUNT = cpu_count() or 4  # fallback to four is None is returned
+
 # ------------------- type aliases (aliai?)
 
 # The waveforms processor type
@@ -378,6 +382,7 @@ xr_type = Union[xr.DataArray, xr.Dataset]
 basic_types = Optional[Union[int, float, str, bool]]
 
 # -------------------------- events validation constants
+
 
 # null quantities for nslc codes
 NULL_NSLC_CODES = (None, "--", "None", "nan", "null", np.nan)

--- a/obsplus/testing.py
+++ b/obsplus/testing.py
@@ -1,0 +1,49 @@
+"""
+Simple utilities used for testing
+"""
+from collections import Counter
+from contextlib import contextmanager
+
+
+@contextmanager
+def instrument_methods(obj):
+    """
+    Temporarily instrument an objects methods.
+
+    This allows the calls to each of the executors methods to be counted. A
+    Counter object is attached to the executor and each of the methods is
+    wrapped to count how many times they are called.
+
+
+    Parameters
+    ----------
+    obj
+    """
+    old_methods = {}
+    counter = Counter()
+    setattr(obj, "_counter", counter)
+
+    for attr in dir(obj):
+        # skip dunders
+        if attr.startswith("__"):
+            continue
+        method = getattr(obj, attr, None)
+        # skip anything that isnt callable
+        if not callable(method):
+            continue
+        # append old method to old_methods and create new method
+        old_methods[attr] = method
+
+        def func(*args, __method_name=attr, **kwargs):
+            counter.update({__method_name: 1})
+            return old_methods[__method_name](*args, **kwargs)
+
+        setattr(obj, attr, func)
+
+    # yield monkey patched object
+    yield obj
+    # reset methods
+    for attr, method in old_methods.items():
+        setattr(obj, attr, method)
+    # delete counter
+    delattr(obj, "_counter")

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -941,7 +941,7 @@ def md5_directory(
             if fnmatch.fnmatch(sub_path.name, exc):
                 keep = False
                 break
-        if sub_path.name.startswith("."):
+        if not hidden and sub_path.name.startswith("."):
             keep = False
         if keep:
             out[str(sub_path.relative_to(path))] = md5(sub_path)

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -8,8 +8,8 @@ import os
 import re
 import sys
 import textwrap
-import threading
-from functools import singledispatch, wraps, lru_cache
+import warnings
+from functools import singledispatch, lru_cache
 from itertools import product
 from pathlib import Path
 from typing import (
@@ -163,6 +163,19 @@ def make_time_chunks(
             t2 = utc2 + overlap
         yield (utc1, t2)
         utc1 += duration  # add duration
+
+
+def try_read_catalog(catalog_path, **kwargs):
+    """ Try to read a events from file, if it raises return None """
+    read = READ_DICT.get(kwargs.pop("format", None), obspy.read_events)
+    try:
+        cat = read(catalog_path, **kwargs)
+    except Exception:
+        warnings.warn(f"obspy failed to read {catalog_path}")
+    else:
+        if cat is not None and len(cat):
+            return cat
+    return None
 
 
 def order_columns(

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -9,7 +9,6 @@ import re
 import sys
 import textwrap
 import threading
-import warnings
 from functools import singledispatch, wraps, lru_cache
 from itertools import product
 from pathlib import Path
@@ -164,19 +163,6 @@ def make_time_chunks(
             t2 = utc2 + overlap
         yield (utc1, t2)
         utc1 += duration  # add duration
-
-
-def try_read_catalog(catalog_path, **kwargs):
-    """ Try to read a events from file, if it raises return None """
-    read = READ_DICT.get(kwargs.pop("format", None), obspy.read_events)
-    try:
-        cat = read(catalog_path, **kwargs)
-    except Exception:
-        warnings.warn(f"obspy failed to read {catalog_path}")
-    else:
-        if cat is not None and len(cat):
-            return cat
-    return None
 
 
 def order_columns(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import shutil
 import tempfile
 import typing
 import warnings
+from concurrent.futures import ThreadPoolExecutor
+from collections import Counter
 from os.path import basename
 from os.path import join, dirname, abspath, exists
 from pathlib import Path
@@ -17,9 +19,10 @@ import obspy
 import pytest
 from obspy.core.event.base import ResourceIdentifier
 
-import obsplus
 import obsplus.datasets.utils
 import obsplus.events.utils
+from obsplus.constants import CPU_COUNT
+from obsplus.testing import instrument_methods
 
 # ------------------------- define constants
 
@@ -189,6 +192,35 @@ class DataSet(typing.NamedTuple):
     station_csv = None
     waveform_path = None
     inventory_path = None
+
+
+@pytest.fixture(scope="class")
+def thread_executor():
+    """ return a thread pool """
+    with ThreadPoolExecutor(CPU_COUNT) as executor:
+        yield executor
+
+
+@pytest.fixture()
+def instrumented_thread_executor(thread_executor):
+    """
+    Return a thread pool executor which has been instrumented.
+
+    This allows the calls to each of the executors methods to be counted. A
+    Counter object is attached to the executor and each of the methods is
+    wrapped to count how many times it is called.
+
+
+    Parameters
+    ----------
+    thread_executor
+
+    Returns
+    -------
+
+    """
+    with instrument_methods(thread_executor):
+        yield thread_executor
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -3,8 +3,11 @@ tests for event wavebank
 """
 import os
 import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, Executor
 from pathlib import Path
 from io import StringIO
+
 
 import obspy
 import obspy.core.event as ev
@@ -210,24 +213,24 @@ class TestReadIndexQueries:
         eve_id = str(catalog[0].resource_id)
         df = bing_ebank.read_index(event_id=eve_id)
         assert len(df) == 1
-        assert eve_id in df.index
+        assert eve_id in set(df["event_id"])
 
     def test_query_resource_id(self, bing_ebank, catalog):
         """ test query on a resource id """
         eve_id = catalog[0].resource_id
         df = bing_ebank.read_index(event_id=eve_id)
         assert len(df) == 1
-        assert str(eve_id) in df.index
+        assert str(eve_id) in set(df["event_id"])
 
     def test_query_event_ids(self, bing_ebank, catalog):
         """
         test querying multiple ids (specifically using something other
         than a list)
         """
-        eve_ids = bing_ebank.read_index().iloc[0:2].index
+        eve_ids = bing_ebank.read_index()["event_id"].iloc[0:2]
         df = bing_ebank.read_index(eventid=eve_ids)
         assert len(df) == 2
-        assert df.index.isin(eve_ids).all()
+        assert df["event_id"].isin(eve_ids).all()
 
     def test_bad_param_raises(self, bing_ebank):
         """ assert bad query param will raise """
@@ -257,7 +260,7 @@ class TestReadIndexQueries:
         These should have been replaced with proper None values.
         """
         df = bing_ebank.read_index()
-        assert not "None" in df.values
+        assert "None" not in df.values
 
     def test_event_description_as_set(self, ebank):
         """
@@ -273,7 +276,7 @@ class TestReadIndexQueries:
             df1 = df_raw[df_raw["event_description"].isin(df_filt)]
             df2 = ebank.read_index(event_description=filt)
             assert len(df1) == len(df2)
-            assert df1.equals(df2)
+            assert df1.reset_index(drop=True).equals(df2.reset_index(drop=True))
 
 
 class TestGetEvents:
@@ -312,8 +315,8 @@ class TestGetEvents:
         """ ensure eventid can accept a numpy array. see #30. """
         ds = crandall_dataset
         ebank = obsplus.EventBank(ds.event_path)
-        # get first two indices
-        inds = ebank.read_index().index[0:2]
+        # get first two event_ids
+        inds = ebank.read_index()["event_id"].values[0:2]
         # query with inds as np array
         assert len(ebank.get_events(eventid=np.array(inds))) == 2
 
@@ -335,6 +338,7 @@ class TestPutEvents:
         """ modify and event and ensure index is updated """
         index1 = bing_ebank.read_index()
         eve = catalog[0]
+        rid = str(eve.resource_id)
         # modify event
         old_lat = eve.origins[0].latitude
         new_lat = old_lat + 0.15
@@ -343,8 +347,9 @@ class TestPutEvents:
         bing_ebank.put_events(eve)
         # read index, ensure event_ids are unique and have correct values
         index2 = bing_ebank.read_index()
+        assert not index2["event_id"].duplicated().any()
         assert len(index1) == len(index2)
-        index_lat = index2.loc[index2.index == str(eve.resource_id), "latitude"]
+        index_lat = index2.loc[index2["event_id"] == rid, "latitude"]
         assert index_lat.iloc[0] == new_lat
 
 
@@ -434,3 +439,29 @@ class TestProgressBar:
         stringio.seek(0)
         out = stringio.read()
         assert "updating or creating" in out
+
+
+class TestConcurrency:
+    """ Tests for using an executor for concurrency. """
+
+    @pytest.fixture()
+    def thread_executor(self):
+        """ create a threadpool executor and return it. """
+        with ThreadPoolExecutor() as executor:
+            yield executor
+
+    def test_executor_get_events(self, thread_executor, ebank, monkeypatch):
+        """ Ensure the threadpool map function is used for reading events. """
+        counter = Counter()
+        old_map = thread_executor.map
+
+        def new_map(*args, **kwargs):
+            counter.update({"calls": 1})
+            return old_map(*args, **kwargs)
+
+        monkeypatch.setattr(thread_executor, "map", new_map)
+        monkeypatch.setattr(ebank, "executor", thread_executor)
+
+        # get events, ensure map is used
+        _ = ebank.get_events()
+        assert counter["calls"], "the executors map function was not called"

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1279,7 +1279,7 @@ class TestConcurrentUpdateIndex:
         return wbank
 
     @pytest.fixture
-    def thread_read(self, concurrent_bank, thread_pool):
+    def thread_read(self, concurrent_bank, thread_executor):
         """ run a bunch of update index operations in different threads,
         return list of results """
         out = []

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -9,6 +9,7 @@ import time
 import types
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
+
 from os.path import join
 from pathlib import Path
 
@@ -575,12 +576,6 @@ class TestGetWaveforms:
         bank.update_index()
         return bank
 
-    @pytest.fixture()
-    def thread_executor(self):
-        """ create a threadpool executor and return it. """
-        with ThreadPoolExecutor() as executor:
-            yield executor
-
     # tests
     def test_attr(self, ta_bank_index):
         """ test that the bank class has the get_waveforms attr """
@@ -651,22 +646,6 @@ class TestGetWaveforms:
         assert len(df) == 3
         st = bank.get_waveforms()
         assert len(st) == 3
-
-    def test_executor_get_waveforrms(self, thread_executor, ta_bank, monkeypatch):
-        """ Ensure the thread pool map function is used for reading waveforms. """
-        counter = Counter()
-        old_map = thread_executor.map
-
-        def new_map(*args, **kwargs):
-            counter.update({"calls": 1})
-            return old_map(*args, **kwargs)
-
-        monkeypatch.setattr(thread_executor, "map", new_map)
-        monkeypatch.setattr(ta_bank, "executor", thread_executor)
-
-        # get events, ensure map is used
-        _ = ta_bank.get_waveforms()
-        assert counter["calls"], "the executors map function was not called"
 
 
 class TestGetBulkWaveforms:

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -9,6 +9,7 @@ import time
 import traceback
 import types
 from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
+from collections import Counter
 from os.path import join
 from pathlib import Path
 
@@ -575,6 +576,12 @@ class TestGetWaveforms:
         bank.update_index()
         return bank
 
+    @pytest.fixture()
+    def thread_executor(self):
+        """ create a threadpool executor and return it. """
+        with ThreadPoolExecutor() as executor:
+            yield executor
+
     # tests
     def test_attr(self, ta_bank_index):
         """ test that the bank class has the get_waveforms attr """
@@ -645,6 +652,22 @@ class TestGetWaveforms:
         assert len(df) == 3
         st = bank.get_waveforms()
         assert len(st) == 3
+
+    def test_executor_get_waveforrms(self, thread_executor, ta_bank, monkeypatch):
+        """ Ensure the thread pool map function is used for reading waveforms. """
+        counter = Counter()
+        old_map = thread_executor.map
+
+        def new_map(*args, **kwargs):
+            counter.update({"calls": 1})
+            return old_map(*args, **kwargs)
+
+        monkeypatch.setattr(thread_executor, "map", new_map)
+        monkeypatch.setattr(ta_bank, "executor", thread_executor)
+
+        # get events, ensure map is used
+        _ = ta_bank.get_waveforms()
+        assert counter["calls"], "the executors map function was not called"
 
 
 class TestGetBulkWaveforms:

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -8,8 +8,7 @@ import tempfile
 import time
 import traceback
 import types
-from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
-from collections import Counter
+from concurrent.futures import as_completed, ProcessPoolExecutor
 from os.path import join
 from pathlib import Path
 
@@ -576,12 +575,6 @@ class TestGetWaveforms:
         bank.update_index()
         return bank
 
-    @pytest.fixture()
-    def thread_executor(self):
-        """ create a threadpool executor and return it. """
-        with ThreadPoolExecutor() as executor:
-            yield executor
-
     # tests
     def test_attr(self, ta_bank_index):
         """ test that the bank class has the get_waveforms attr """
@@ -652,22 +645,6 @@ class TestGetWaveforms:
         assert len(df) == 3
         st = bank.get_waveforms()
         assert len(st) == 3
-
-    def test_executor_get_waveforrms(self, thread_executor, ta_bank, monkeypatch):
-        """ Ensure the thread pool map function is used for reading waveforms. """
-        counter = Counter()
-        old_map = thread_executor.map
-
-        def new_map(*args, **kwargs):
-            counter.update({"calls": 1})
-            return old_map(*args, **kwargs)
-
-        monkeypatch.setattr(thread_executor, "map", new_map)
-        monkeypatch.setattr(ta_bank, "executor", thread_executor)
-
-        # get events, ensure map is used
-        _ = ta_bank.get_waveforms()
-        assert counter["calls"], "the executors map function was not called"
 
 
 class TestGetBulkWaveforms:
@@ -1249,6 +1226,31 @@ class TestBadInputs:
             sbank.WaveBank(tmp_ta_dir, inventory="some none existent file")
 
 
+class TestConcurrentReads:
+    """
+    Tests for concurrent reads.
+    """
+
+    @pytest.fixture
+    def wbank_executor(self, ta_bank, monkeypatch, instrumented_thread_executor):
+        """ Return a wavebank with an instrumented executor. """
+        monkeypatch.setattr(ta_bank, "executor", instrumented_thread_executor)
+        os.remove(ta_bank.index_path)
+        return ta_bank
+
+    def test_concurrent_get_waveforms(self, wbank_executor):
+        """ Ensure conccurent get_waveforms uses executor. """
+        _ = wbank_executor.get_waveforms()
+        counter = getattr(wbank_executor.executor, "_counter", {})
+        assert counter.get("map", 0) > 0
+
+    def test_concurrent_update_index(self, wbank_executor):
+        """ Ensure updating index can be performed with executor. """
+        _ = wbank_executor.update_index()
+        counter = getattr(wbank_executor.executor, "_counter", {})
+        assert counter.get("map", 0) > 0
+
+
 class TestConcurrentUpdateIndex:
     """
     Tests to make sure running update index in different threads/processes.
@@ -1275,12 +1277,6 @@ class TestConcurrentUpdateIndex:
         self.func(wbank)
         return wbank
 
-    @pytest.fixture(scope="class")
-    def thread_pool(self):
-        """ return a thread pool """
-        with ThreadPoolExecutor(self.worker_count) as executor:
-            yield executor
-
     @pytest.fixture
     def thread_read(self, concurrent_bank, thread_pool):
         """ run a bunch of update index operations in different threads,
@@ -1289,7 +1285,7 @@ class TestConcurrentUpdateIndex:
         concurrent_bank.update_index()
         func = functools.partial(self.func, wbank=concurrent_bank)
         for _ in range(self.worker_count):
-            out.append(thread_pool.submit(func))
+            out.append(thread_executor.submit(func))
         return list(as_completed(out))
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
This PR attempts to add support for `Bank` objects to use `Executor`-like objects (anything with a `map` method) for both reading files from disk, as in `get_waveforms` or `get_events`, as well as `update_index` operations. `Bank` instances now have an `executor` attribute, which can be set in the `__init__` or as an attribute to enable concurrency. 

