### PR TITLE
remove concurrent update features

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,8 @@ obsplus master:
       and for further customizability (see #106).
     * Removed min_file_for_bar argument in favor of class attribute of
       _min_files_for_bar (see #106).
-    * Add support for circular searches on EventBank (see #110)
+    * Add support for circular searches on EventBank (see #110).
+    * Removed concurrent update features for WaveBank (see #117).
   - obsplus.interfaces
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the

--- a/docs/modules/obsplus.utils.rst
+++ b/docs/modules/obsplus.utils.rst
@@ -22,7 +22,6 @@ obsplus.utils
       order_columns
       read_file
       register_func
-      thread_lock_function
       to_timestamp
       try_read_catalog
       yield_obj_parent_attr

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -40,12 +40,6 @@ class _Bank(ABC):
     bank_path = ""
     namespace = ""
     index_name = ".index.h5"  # name of index file
-    # indexing process down.
-    # concurrency handling features
-    _lock_file_name = ".~obsplus_hdf5.lock"
-    _owns_lock = False
-    _concurrent = False
-    _index_lock = threading.RLock()  # lock for updating index thread
     # optional str defining the directory structure and file name schemes
     path_structure = None
     name_structure = None
@@ -82,13 +76,6 @@ class _Bank(ABC):
         The expected path to the index file.
         """
         return join(self.bank_path, self.index_name)
-
-    @property
-    def lock_file_path(self):
-        """
-        The expected path for the lock file.
-        """
-        return join(self.bank_path, self._lock_file_name)
 
     @property
     def _index_node(self):
@@ -171,63 +158,6 @@ class _Bank(ABC):
         if not path.is_dir():
             msg = f"{path} is not a directory, cant read bank"
             raise BankDoesNotExistError(msg)
-
-    def block_on_index_lock(self, wait_interval=0.2, max_retry=10):
-        """
-        Blocks until the lock is released.
-
-        Will wait a certain number of seconds a certain number of times
-        before raising a BankIndexLockError.
-
-        Parameters
-        ----------
-        wait_interval
-            The number of seconds to wait between each try
-        max_retry
-            The number of times to retry before raising.
-        """
-        # if the concurrent feature is not selected just bail out
-        if not self._concurrent:
-            return
-        # if there is no lock, or this bank owns the lock return
-        if not os.path.exists(self.lock_file_path) or self._owns_lock:
-            return
-        # get random state, based on process id, for waiting random seconds
-        rand = np.random.RandomState(os.getpid() or 13)
-        # wait until the lock file is gone or timeout occurs (then raise)
-        count = 0
-        while count < max_retry:
-            if not os.path.exists(self.lock_file_path):
-                return
-            time.sleep(wait_interval + rand.rand() * wait_interval)
-            count += 1
-        else:
-            duration = max_retry * wait_interval
-            msg = (
-                f"{self.lock_file_path} was not released after about "
-                f"{duration * 1.5} seconds. It may need to be manually deleted"
-                f" if the index is not in the process of being updated."
-            )
-            raise BankIndexLockError(msg)
-
-    @contextmanager
-    def lock_index(self):
-        """
-        Acquire lock for work inside context manager.
-        """
-        if self._concurrent:
-            self.block_on_index_lock()  # ensure lock isn't already in use
-            assert Path(self.bank_path).exists()
-            open(self.lock_file_path, "w").close()  # create lock file
-            self._owns_lock = True
-            # close all open files (nothing should have tables at this point)
-            gc.collect()  # must call GC to ensure everything is cleaned up (ugly)
-            tables.file._open_files.close_all()
-        yield
-        if self._concurrent:
-            with suppress(FileNotFoundError):
-                os.unlink(self.lock_file_path)
-            self._owns_lock = False
 
     def get_progress_bar(self, bar=None) -> Optional[ProgressBar]:
         """

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -17,7 +17,6 @@ import pandas as pd
 
 import obsplus
 import obsplus.events.pd
-from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.bank.core import _Bank
 from obsplus.bank.utils import (
     _IndexCache,
@@ -34,14 +33,10 @@ from obsplus.constants import (
     get_events_parameters,
     bar_paramter_description,
 )
+from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.exceptions import BankDoesNotExistError
-from obsplus.utils import (
-    try_read_catalog,
-    get_progressbar,
-    thread_lock_function,
-    compose_docstring,
-)
 from obsplus.interfaces import ProgressBar
+from obsplus.utils import try_read_catalog, compose_docstring
 
 # --- define static types
 
@@ -191,7 +186,6 @@ class EventBank(_Bank):
             df = df[df.event_id.isin(circular_ids)]
         return df.set_index("event_id")
 
-    @thread_lock_function()
     @compose_docstring(bar_paramter_description=bar_paramter_description)
     def update_index(self, bar: Optional[ProgressBar] = None) -> "EventBank":
         """

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -438,30 +438,6 @@ def get_progressbar(
     return bar
 
 
-def thread_lock_function(lock=None):
-    """
-    A decorator for locking a function that should never be run by more than
-    one thread.
-
-    Parameters
-    ----------
-    lock
-        An RLock or Lock object from the threading module, or an object that
-        has the same interface.
-    """
-    lock = lock or threading.RLock()
-
-    def _decorator(func):
-        @wraps(func)
-        def _wrapper(*args, **kwargs):
-            with lock:
-                return func(*args, **kwargs)
-
-        return _wrapper
-
-    return _decorator
-
-
 def iterate(obj):
     """
     Return an iterable from any object.


### PR DESCRIPTION
This PR completely removes the concurrent update features from `WaveBank`. The locking mechanism is simply too buggy and causes frequent fails in the CI. 

I have created a package which we will use to ensure the reads and updates all go through a single process/thread [here](https://github.com/d-chambers/srpo), which will provide this functionality if needed. 

Also, just a reminder, concurrent reads are fully supported. This change only effects concurrent updates. See #114 for more info.