### PR TITLE
Update interfaces

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,9 @@ obsplus master:
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the
       progressbar2 library (see #106).
+  - obsplus.stations
+    * Fixed issue where networks and stations could be left un-pruned when
+      querying on channel (see #115).
 
 obsplus 0.0.2:
   - obsplus.bank

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -4,8 +4,11 @@ Some common interfaces for event/client types.
 Note: These are used instead of the ones in obspy.clients.base so the subclass
 hooks can be used.
 """
-from abc import ABC, abstractmethod
+import inspect
+from abc import abstractmethod
+
 import obspy
+import pandas as pd
 
 
 def add_func_name(my_set: set):
@@ -21,51 +24,66 @@ def add_func_name(my_set: set):
 class _MethodChecker(type):
     """ class for checking if methods exist """
 
-    required_methods: set = set()
+    def __init__(cls, name, bases, arg_dict):
+        # get all methods defined by class
+        methods = {
+            i for i, v in arg_dict.items() if not i.startswith("_") and callable(v)
+        }
+        cls._required_methods = methods
 
-    def __subclasshook__(cls, C):
-        methods = {x for B in C.__mro__ for x in B.__dict__}
-        if cls.required_methods.issubset(methods):
+    def __subclasscheck__(cls, subclass):
+        if not inspect.isclass(subclass):
+            return False
+        methods = {x for B in subclass.__mro__ for x in B.__dict__}
+        if cls._required_methods.issubset(methods):
             return True
-        return NotImplemented
+        return False
 
-    # def __instancecheck__(cls, instance):
-    #     if set(cls.required_methods).issubset(dir(instance)):
-    #         return True
-    #     return super().__instancecheck__(cls, instance)
-    #     # return NotImplemented
+    def __instancecheck__(cls, instance):
+        is_instance = not inspect.isclass(instance)
+        if is_instance and set(cls._required_methods).issubset(dir(instance)):
+            return True
+        return False
 
 
 class EventClient(metaclass=_MethodChecker):
     """ The event client interface """
 
-    required_methods = {"get_events"}
+    @abstractmethod
+    def get_events(self, *args, **kwargs) -> obspy.Catalog:
+        """ A method which must return events as obspy.Catalog object. """
 
 
 class WaveformClient(metaclass=_MethodChecker):
-    """ The waveform client interface"""
+    """ The waveform client interface. """
 
-    required_methods = {"get_waveforms"}
+    @abstractmethod
+    def get_waveforms(
+        self, network, station, location, channel, starttime, endtime
+    ) -> obspy.Stream:
+        """ A method which must return waveforms as an obspy.Stream. """
 
 
 class StationClient(metaclass=_MethodChecker):
     """ The station client interface """
 
-    required_methods = {"get_stations"}
+    @abstractmethod
+    def get_stations(self, *args, **kwargs) -> obspy.Inventory:
+        """ A method which must return an inventory object. """
 
 
 class BankType(metaclass=_MethodChecker):
     """ an object that looks like a bank """
 
-    required_methods = {"read_index"}
+    @abstractmethod
+    def read_index(self, *args, **kwargs) -> pd.DataFrame:
+        """ A method which must return a dataframe of index contents. """
 
 
 class ProgressBar(metaclass=_MethodChecker):
     """
     A class that behaves like the progressbar2.ProgressBar class.
     """
-
-    required_methods: set = {"update", "finish"}
 
     @abstractmethod
     def update(self, value=None, force=False, **kwargs):

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -18,45 +18,49 @@ def add_func_name(my_set: set):
     return _wrap
 
 
-class _MethodChecker:
+class _MethodChecker(type):
     """ class for checking if methods exist """
 
     required_methods: set = set()
 
-    @classmethod
     def __subclasshook__(cls, C):
         methods = {x for B in C.__mro__ for x in B.__dict__}
         if cls.required_methods.issubset(methods):
             return True
-        else:
-            return NotImplemented
+        return NotImplemented
+
+    # def __instancecheck__(cls, instance):
+    #     if set(cls.required_methods).issubset(dir(instance)):
+    #         return True
+    #     return super().__instancecheck__(cls, instance)
+    #     # return NotImplemented
 
 
-class EventClient(ABC, _MethodChecker):
+class EventClient(metaclass=_MethodChecker):
     """ The event client interface """
 
     required_methods = {"get_events"}
 
 
-class WaveformClient(ABC, _MethodChecker):
+class WaveformClient(metaclass=_MethodChecker):
     """ The waveform client interface"""
 
     required_methods = {"get_waveforms"}
 
 
-class StationClient(ABC, _MethodChecker):
+class StationClient(metaclass=_MethodChecker):
     """ The station client interface """
 
     required_methods = {"get_stations"}
 
 
-class BankType(ABC, _MethodChecker):
+class BankType(metaclass=_MethodChecker):
     """ an object that looks like a bank """
 
     required_methods = {"read_index"}
 
 
-class ProgressBar(ABC, _MethodChecker):
+class ProgressBar(metaclass=_MethodChecker):
     """
     A class that behaves like the progressbar2.ProgressBar class.
     """
@@ -73,6 +77,6 @@ class ProgressBar(ABC, _MethodChecker):
 
 
 # register virtual subclasses
-WaveformClient.register(obspy.Stream)
-EventClient.register(obspy.Catalog)
-StationClient.register(obspy.Inventory)
+# WaveformClient.register(obspy.Stream)
+# EventClient.register(obspy.Catalog)
+# StationClient.register(obspy.Inventory)

--- a/obsplus/stations/get_stations.py
+++ b/obsplus/stations/get_stations.py
@@ -80,6 +80,7 @@ def _keep_obj(obj, **kwargs) -> bool:
     the required attrs and meet the requirements.
     """
     assert set(PARAMS).issuperset(set(kwargs))
+    met_requirement = False  # switch if any requirements have been met
     for parameter, requirement in kwargs.items():
         attr, oper = PARAMS[parameter], OPERATORS[parameter]
         # add network, station, channel codes if applicable
@@ -87,7 +88,9 @@ def _keep_obj(obj, **kwargs) -> bool:
             value = getattr(obj, attr)
             if not oper(value, requirement):
                 return False
-    return True
+            else:
+                met_requirement = True
+    return met_requirement
 
 
 def _filter(obj, cls, **kwargs):

--- a/obsplus/stations/utils.py
+++ b/obsplus/stations/utils.py
@@ -25,6 +25,9 @@ mapping_keys = {
 }
 
 
+type_mappings = {"start_date": obspy.UTCDateTime, "end_date": obspy.UTCDateTime}
+
+
 def df_to_inventory(df) -> obspy.Inventory:
     """
     Create a simple inventory from a dataframe.
@@ -64,14 +67,18 @@ def df_to_inventory(df) -> obspy.Inventory:
 
     def _get_kwargs(series, key_mapping):
         """ create the kwargs from a series and key mapping. """
-
         out = {}
         for k, v in key_mapping.items():
             # skip if requested kwarg is not in the series
             if v not in series:
                 continue
             value = series[v]
-            out[k] = value if not pd.isnull(value) else None
+            value = value if not pd.isnull(value) else None
+            # if the type needs to be cast to something else
+            if k in type_mappings and value is not None:
+                value = type_mappings[k](value)
+            out[k] = value
+
         return out
 
     # first get key_mappings

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -26,12 +26,10 @@ class TestEventClient:
     def test_fdsn_isinstance(self, iris_client):
         """ ensure the client is an instance of EventClient """
         assert isinstance(iris_client, EventClient)
-        breakpoint()
-        isinstance(10, EventClient)
-
         assert not isinstance(10, EventClient)
 
     def test_fdsn_issubclass(self):
+        issubclass(str, EventClient)
         assert issubclass(Client, EventClient)
         assert not issubclass(str, EventClient)
 
@@ -66,22 +64,6 @@ class TestWaveformClient:
         wavebank = bingham_dataset.waveform_client
         assert isinstance(wavebank, WaveformClient)
         assert issubclass(WaveBank, WaveformClient)
-
-    def test_cls_with_getattr(self, bingham_dataset):
-        """
-        A class that returns objects for the appropriate attributes
-        with getattr rather than explicit methods should still be a
-        subclass/instances.
-        """
-        wavebank = bingham_dataset.waveform_client
-
-        class MockWaveform:
-            def __getattr__(self, item):
-                if item == "get_waveforms":
-                    return wavebank.get_waveforms
-                raise AttributeError(f"No such attribute {item}")
-
-        assert isinstance(MockWaveform(), WaveformClient)
 
 
 class TestStationClient:
@@ -119,6 +101,11 @@ class TestBar:
 
         assert issubclass(MyBar, ProgressBar)
         assert isinstance(MyBar(), ProgressBar)
+        # the class should not be an instance
+        isinstance(MyBar, ProgressBar)
+        assert not isinstance(MyBar, ProgressBar)
+        # the instance should not be a subclass
+        assert not issubclass(MyBar(), ProgressBar)
 
     def test_malformed_progress_bar(self):
         """

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -26,6 +26,9 @@ class TestEventClient:
     def test_fdsn_isinstance(self, iris_client):
         """ ensure the client is an instance of EventClient """
         assert isinstance(iris_client, EventClient)
+        breakpoint()
+        isinstance(10, EventClient)
+
         assert not isinstance(10, EventClient)
 
     def test_fdsn_issubclass(self):
@@ -63,6 +66,22 @@ class TestWaveformClient:
         wavebank = bingham_dataset.waveform_client
         assert isinstance(wavebank, WaveformClient)
         assert issubclass(WaveBank, WaveformClient)
+
+    def test_cls_with_getattr(self, bingham_dataset):
+        """
+        A class that returns objects for the appropriate attributes
+        with getattr rather than explicit methods should still be a
+        subclass/instances.
+        """
+        wavebank = bingham_dataset.waveform_client
+
+        class MockWaveform:
+            def __getattr__(self, item):
+                if item == "get_waveforms":
+                    return wavebank.get_waveforms
+                raise AttributeError(f"No such attribute {item}")
+
+        assert isinstance(MockWaveform(), WaveformClient)
 
 
 class TestStationClient:

--- a/tests/test_stations/test_stations_utils.py
+++ b/tests/test_stations/test_stations_utils.py
@@ -13,6 +13,14 @@ from obsplus.stations.utils import df_to_inventory
 class TestDfToInventory:
     """ Tests for converting a dataframe to an obspy Inventory. """
 
+    @staticmethod
+    def _assert_dates_are_utc_or_none(obj):
+        """ assert the start_date and end_date are UTC instances or None """
+        start = getattr(obj, "start_date", None)
+        end = getattr(obj, "end_date", None)
+        for attr in [start, end]:
+            assert isinstance(attr, obspy.UTCDateTime) or attr is None
+
     @pytest.fixture
     def df_from_inv(self):
         """ convert the default inventory to a df and return. """
@@ -42,6 +50,16 @@ class TestDfToInventory:
         df1 = df1[columns].sort_values(columns).reset_index(drop=True)
         df2 = df2[columns].sort_values(columns).reset_index(drop=True)
         assert df1.equals(df2)
+
+    def test_dates_are_utc_datetime_objects(self, inv_from_df):
+        """
+        All the dates should be either None or instances of UTCDateTime.
+        """
+        for net in inv_from_df:
+            for sta in net:
+                self._assert_dates_are_utc_or_none(sta)
+                for cha in sta:
+                    self._assert_dates_are_utc_or_none(cha)
 
     def test_NaN_in_non_time_columns(self, df_from_inv):
         """


### PR DESCRIPTION
This PR updates (fixes) how the interfaces (`WaveformClient`, `EventClient`, ...) work. Now `isinstance` as well as `issubclass` should work on objects which have the expected attributes.