### PR TITLE
Add ability to get NRL responses in dataframe to inventory

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,8 @@ obsplus master:
       querying on channel (see #115).
   - obsplus.utils
     * Deprecate get_nslc_series in favor of get_seed_id_series (#120).
+  - obsplus.events
+    * Dataframe_to_inventory can now fetch NRL responses (#125).
 
 obsplus 0.0.2:
   - obsplus.bank

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -223,13 +223,12 @@ def order_columns(
     """
     if df.empty:
         return pd.DataFrame(columns=required_columns)
-    # add any extra columns if needed
-    if not set(df.columns).issuperset(required_columns):
-        df = df.reindex(columns=required_columns)
     # make sure required columns are there
     column_set = set(df.columns)
     extra_cols = sorted(list(column_set - set(required_columns)))
     new_cols = list(required_columns) + extra_cols
+    # add any extra (blank) columns if needed and sort
+    df = df.reindex(columns=new_cols)
     # cast network, station, location, channel, to str
     if dtype:
         used = set(dtype) & set(df.columns)
@@ -239,8 +238,7 @@ def order_columns(
             df = df.replace(replace)
         except Exception:
             pass
-    assert column_set == set(new_cols)
-    return df[new_cols]
+    return df
 
 
 def read_file(file_path, funcs=(pd.read_csv,)) -> Optional[Any]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 test=pytest; pytest docs --nbval
 [tool:pytest]
 testpaths = tests
+markers =
+    requires_network: test requires network access
+    dataset: test will re-download datasets (skipped by default)

--- a/tests/test_stations/test_stations_utils.py
+++ b/tests/test_stations/test_stations_utils.py
@@ -63,6 +63,8 @@ class TestDfToInventory:
         # keep one as a tuple and convert the other to str
         df["sensor_keys"] = [sensor_keys for _ in range(len(df))]
         df["datalogger_keys"] = "__".join(datalogger_keys)
+        # drop seed id
+        df = df.drop(columns="seed_id")
         return df
 
     def test_type(self, inv_from_df):
@@ -109,6 +111,7 @@ class TestDfToInventory:
         inv_sub = inv.get_stations(**kwargs)
         assert inv_sub[0][0][0].azimuth is None
 
+    @pytest.mark.requires_network
     def test_response(self, df_with_response):
         """ Ensure the NRL is used to pull responses. """
         inv = df_to_inventory(df_with_response)


### PR DESCRIPTION
This PR allows `obsplus.events.utils.dataframe_to_inventory` to fetch responses using obspy's [NRL client](https://docs.obspy.org/master/packages/obspy.clients.nrl.html) if the columns `datalogger_keys` and sensor_keys` are found and not null. 