### PR TITLE
Stream almost equal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,10 @@ obsplus master:
     * Deprecate get_nslc_series in favor of get_seed_id_series (#120).
   - obsplus.events
     * Dataframe_to_inventory can now fetch NRL responses (#125).
+  - obsplus.waveforms
+    * Added assert_streams_almost_equal method (see #128).
+    * The function obsplus.waveforms.stream_split_bulk now has more flexible
+      inputs (see #128).
 
 obsplus 0.0.2:
   - obsplus.bank

--- a/obsplus/waveforms/utils.py
+++ b/obsplus/waveforms/utils.py
@@ -24,9 +24,6 @@ from obsplus.constants import (
 from obsplus.interfaces import WaveformClient
 from obsplus.utils import get_seed_id_series, filter_index
 
-# The keys for simple stats
-SIMPLE_STATS = list(NSLC) + ["sampling_rate", "starttime", "endtime"]
-
 
 # ---------- trim functions
 
@@ -486,6 +483,88 @@ def _get_waveclient_from_path(path):
         return get_waveform_client(obspy.read(str(path)))
 
 
+class _StreamEqualTester:
+    """
+    Simple class for testing if streams are (almost) equal.
+
+    This class is not intended to be used directly, instead use
+    :func:`obsplus.waveforms.utils.assert_stream_almost_equal`.
+    """
+
+    skeys = list(NSLC) + ["sampling_rate", "starttime", "endtime"]
+
+    def __init__(
+        self,
+        basic_stats: bool = True,
+        atol: float = 1e-05,
+        rtol: float = 1e-08,
+        equal_nan: bool = True,
+        allow_off_by_one: bool = False,
+    ):
+        self.basic_stats = basic_stats
+        self.atol = atol
+        self.rtol = rtol
+        self.equal_nan = equal_nan
+        self.allow_off_by_one = allow_off_by_one
+
+    def _assert_stats_equal(self, tr1, tr2):
+        """ Assert that the stats dicts are almost equal. """
+        skeys, basic_stats = self.skeys, self.basic_stats
+        sta1 = {x: tr1.stats[x] for x in skeys} if basic_stats else tr1.stats
+        sta2 = {x: tr2.stats[x] for x in skeys} if basic_stats else tr2.stats
+        if not sta1 == sta2:
+            stats_equal = False
+            # see if the start and end times are within one sample rate
+            if self.allow_off_by_one:
+                times = ("starttime", "endtime")
+                sta1_new = {i: v for i, v in sta1.items() if i not in times}
+                sta2_new = {i: v for i, v in sta2.items() if i not in times}
+                if sta1["sampling_rate"] == sta2["sampling_rate"]:
+                    sr = sta1["sampling_rate"]
+                    t1_diff = abs(sta1["starttime"] - sta2["starttime"])
+                    t2_diff = abs(sta1["endtime"] - sta2["starttime"])
+                    if t1_diff < sr and t2_diff < sr and sta1_new == sta2_new:
+                        stats_equal = True
+            if not stats_equal:
+                msg = f"Stats are not the same for the traces: \n{sta1}\n{sta2}"
+                assert 0, msg
+
+    def _assert_arrays_almost_equal(self, tr1, tr2):
+        """ Assert that the data arrays of the traces are almost equal. """
+        ars = sorted([tr1.data, tr2.data], key=lambda x: len(x))
+        kwargs = dict(atol=self.atol, rtol=self.rtol, equal_nan=self.equal_nan)
+        close = np.allclose(ars[0], ars[1], **kwargs)
+        if not close and self.allow_off_by_one:
+            # If the arrays are within 2 samples of each other in length
+            if abs(len(ars[0]) - len(ars[1])) <= 2:
+                sub_ar = ars[0][1:-1]
+                # slide the smaller array over the larger, return true if found
+                for i in range(len(ars[1]) - len(ars[0]) + 3):
+                    if np.allclose(sub_ar, ars[1][i : i + len(sub_ar)], **kwargs):
+                        close = True
+                        break
+        assert close, "Data of traces are not nearly equal"
+
+    def __call__(self, st1, st2):
+        """
+        Assert that two streams are almost equal else raise AssertionError.
+
+        Parameters
+        ----------
+        st1
+            The first stream
+        st2
+            The second stream
+        """
+        st1.sort(), st2.sort()
+        if len(st1) != len(st2):
+            assert 0, "streams do not have the same number of traces"
+        # iterate each trace and raise if stats and arrays are not almost equal.
+        for tr1, tr2 in zip(st1, st2):
+            self._assert_stats_equal(tr1, tr2)
+            self._assert_arrays_almost_equal(tr1, tr2)
+
+
 def assert_streams_almost_equal(
     st1: obspy.Stream,
     st2: obspy.Stream,
@@ -524,53 +603,11 @@ def assert_streams_almost_equal(
     ------
     AssertionError if streams are not about equal.
     """
-    st1.sort(), st2.sort()
-    if len(st1) != len(st2):
-        assert 0, "streams do not have the same number of traces"
-    for tr1, tr2 in zip(st1, st2):
-        args = (tr1, tr2, basic_stats, atol, rtol, equal_nan, allow_off_by_one)
-        _assert_traces_almost_equal(*args)
-
-
-def _assert_traces_almost_equal(
-    tr1: obspy.Trace,
-    tr2: obspy.Trace,
-    basic_stats: bool = True,
-    atol: float = 1e-05,
-    rtol: float = 1e-08,
-    equal_nan: bool = True,
-    allow_off_by_one=False,
-) -> None:
-    """ Assert that traces are equal. """
-    # work with stats
-    sta1 = {x: tr1.stats[x] for x in SIMPLE_STATS} if basic_stats else tr1.stats
-    sta2 = {x: tr2.stats[x] for x in SIMPLE_STATS} if basic_stats else tr2.stats
-    if not sta1 == sta2:
-        stats_equal = False
-        # see if the start and end times are within one sample rate
-        if allow_off_by_one:
-            times = ("starttime", "endtime")
-            sta1_new = {i: v for i, v in sta1.items() if i not in times}
-            sta2_new = {i: v for i, v in sta2.items() if i not in times}
-            if sta1["sampling_rate"] == sta2["sampling_rate"]:
-                sr = sta1["sampling_rate"]
-                t1_diff = abs(sta1["starttime"] - sta2["starttime"])
-                t2_diff = abs(sta1["endtime"] - sta2["starttime"])
-                if t1_diff < sr and t2_diff < sr and sta1_new == sta2_new:
-                    stats_equal = True
-        if not stats_equal:
-            msg = f"Stats are not the same for the traces: \n{sta1}\n{sta2}"
-            assert 0, msg
-    # now check the arrays
-    ars = sorted([tr1.data, tr2.data], key=lambda x: len(x))
-    kwargs = dict(atol=atol, rtol=rtol, equal_nan=equal_nan)
-    close = np.allclose(ars[0], ars[1], **kwargs)
-    if not close and allow_off_by_one:
-        # If the arrays are within 2 samples of each other in length
-        if abs(len(ars[0]) - len(ars[1])) <= 2:
-            sub_ar = ars[0][1:-1]
-            # slide the smaller array over the larger, return true if found
-            for i in range(len(ars[1]) - len(ars[0]) + 3):
-                if np.allclose(sub_ar, ars[1][i : i + len(sub_ar)], **kwargs):
-                    close = True
-    assert close, "Data of traces are not nearly equal"
+    kwargs = dict(
+        basic_stats=basic_stats,
+        atol=atol,
+        rtol=rtol,
+        equal_nan=equal_nan,
+        allow_off_by_one=allow_off_by_one,
+    )
+    _StreamEqualTester(**kwargs)(st1, st2)

--- a/tests/test_stations/test_pd_stations.py
+++ b/tests/test_stations/test_pd_stations.py
@@ -183,13 +183,14 @@ class TestReadKemInventory:
     sml_path = kem_ds.source_path / "inventory.xml"
     sml = obspy.read_inventory(str(sml_path))
     df = pd.read_csv(csv_path)
-    supported_inputs = [sml_path, sml, df, csv_path]
+    supported_inputs = ["sml_path", "sml", "csv_path", "df"]
 
     # fixtures
     @pytest.fixture(scope="class", params=supported_inputs)
     def inv_df(self, request):
         """ collect all the supported inputs are parametrize"""
-        return stations_to_df(request.param)
+        name = request.param
+        return stations_to_df(getattr(self, name))
 
     # tests
     def test_size(self, inv_df):

--- a/tests/test_waveforms/test_waveforms_utils.py
+++ b/tests/test_waveforms/test_waveforms_utils.py
@@ -411,7 +411,7 @@ class TestStreamBulkSplit:
             assert_streams_almost_equal(st1, st2, allow_off_by_one=True)
 
 
-class TestAssertWaveformsEqual:
+class TestAssertStreamsAlmostEqual:
     """ Tests for asserting waveforms are equal. """
 
     @pytest.fixture


### PR DESCRIPTION
This PR  does two things:

1. Adds a function called `assert_stream_almost_equal` for testing streams that are, well, "almost" equal. This functionality should be moved to obspy when python 2 is dropped. Currently obspy has a form of this that is less comprehensive. 

2. Adds support for additional bulk argument types in `obsplus.waveforms.stream_split_bulk`. Specifically, dataframes can now be passed provided they have columns named "network",
 "station", "location", "channel", "starttime", and "endtime".
