### PR TITLE
Deal with integer NSLC edge case for df_to_inv

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,8 @@ obsplus master:
   - obsplus.stations
     * Fixed issue where networks and stations could be left un-pruned when
       querying on channel (see #115).
+    * Handled an edge case in df_to_inv where an integer NSLC code gets
+      misinterpreted by pandas (see #130 and #132).
   - obsplus.utils
     * Deprecate get_nslc_series in favor of get_seed_id_series (#120).
   - obsplus.validate

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -66,6 +66,22 @@ STATION_DTYPES = OrderedDict(
 
 STATION_COLUMNS = tuple(STATION_DTYPES)
 
+DF_TO_INV_DTYPES = OrderedDict(
+    network=str,
+    station=str,
+    location=str,
+    channel=str,
+    latitude=float,
+    longitude=float,
+    elevation=float,
+    depth=float,
+    sample_rate=float,
+    start_date=float,
+    end_date=float,
+)
+
+DF_TO_INV_COLUMNS = tuple(DF_TO_INV_DTYPES)
+
 # columns required for event_data
 EVENT_DTYPES = OrderedDict(
     time=float,

--- a/obsplus/stations/utils.py
+++ b/obsplus/stations/utils.py
@@ -13,7 +13,6 @@ from obspy.core.inventory import Channel, Station, Network
 import obsplus
 from obsplus.constants import station_clientable_type, NSLC
 from obsplus.interfaces import StationClient
-from obsplus.utils import order_columns
 
 LARGE_NUMBER = obspy.UTCDateTime("3000-01-01").timestamp
 

--- a/obsplus/stations/utils.py
+++ b/obsplus/stations/utils.py
@@ -11,8 +11,9 @@ import pandas as pd
 from obspy.core.inventory import Channel, Station, Network
 
 import obsplus
-from obsplus.constants import station_clientable_type
+from obsplus.constants import station_clientable_type, NSLC
 from obsplus.interfaces import StationClient
+from obsplus.utils import order_columns
 
 LARGE_NUMBER = obspy.UTCDateTime("3000-01-01").timestamp
 
@@ -123,6 +124,10 @@ def df_to_inventory(df) -> obspy.Inventory:
             return
         # at this point all the required info for resp lookup should be there
         channel_kwargs["response"] = get_response(datalogger_keys, sensor_keys)
+
+    # Deal with pandas dtype weirdness
+    for col in NSLC:
+        df[col] = df[col].astype(str).str.replace(".0", "")
 
     # first get key_mappings
     net_map = _make_key_mappings(Network)

--- a/obsplus/stations/utils.py
+++ b/obsplus/stations/utils.py
@@ -125,6 +125,8 @@ def df_to_inventory(df) -> obspy.Inventory:
         channel_kwargs["response"] = get_response(datalogger_keys, sensor_keys)
 
     # Deal with pandas dtype weirdness
+    # TODO remove this when custom column functions are supported by DataFrame
+    #  Extractor (part of the big refactor in #131)
     for col in NSLC:
         df[col] = df[col].astype(str).str.replace(".0", "")
 

--- a/tests/test_events/test_get_events.py
+++ b/tests/test_events/test_get_events.py
@@ -86,7 +86,7 @@ class TestGetEvents:
 
     def test_max_min_radius_m(self, catalog):
         """ Ensure max and min radius work in m (ie when degrees=False). """
-        minrad = 10_000
+        minrad = 10000
         maxrad = 800_000
         lat, lon = 39.342, 41.044
         kwargs = dict(

--- a/tests/test_stations/test_stations_utils.py
+++ b/tests/test_stations/test_stations_utils.py
@@ -42,37 +42,10 @@ class TestDfToInventory:
     @pytest.fixture
     def dummy_df(self):
         """ df 'inventory' with odd data types for the NSLC columns """
-        return pd.DataFrame(
-            [
-                [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    40.0,
-                    -111.0,
-                    2000,
-                    0,
-                    250,
-                    "2019-01-01",
-                    "2020-01-01",
-                ],
-                [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    40.0,
-                    -111.0,
-                    2000,
-                    0,
-                    250,
-                    "2020-01-01",
-                    "2200-01-01",
-                ],
-            ],
-            columns=DF_TO_INV_COLUMNS,
-        )
+        numerics = [1.0, 1.0, 1.0, 1.0, 40.0, -111.0, 2000, 0, 250]
+        row1 = numerics + ["2019-01-01", "2020-01-01"]
+        row2 = numerics + ["2020-01-01", "2200-01-01"]
+        return pd.DataFrame([row1, row2], columns=DF_TO_INV_COLUMNS)
 
     @pytest.fixture
     def df_with_response(self):


### PR DESCRIPTION
This addresses an edge case where NSLCs that have integer labels will get converted to floats by pandas, resulting in '1.0.1.0.1.0.1.0' for the seed string rather than '1.1.1.1'. See #130. 

The fix works by explicitly changing the dtype of the NSLC columns to `str` and stripping off a `.0` if it is present. I'm fairly certain this should not cause problems elsewhere because the NSLCs should never have '.'s in them, but let me know if you can think of any case where this might break things or a more elegant idea.