### PR TITLE
refactor pipelines config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
   - bash: |
         source activate $(env_name)
         flake8
-      displayName: flake8
+    displayName: flake8
 
   - bash: |
       source activate $(env_name)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,15 +46,24 @@ jobs:
     displayName: Create Anaconda environment
 
   - bash: |
-      source activate $(env_name)
-      flake8
-    displayName: flake8
+        source activate $(env_name)
+        flake8
+      displayName: flake8
 
   - bash: |
       source activate $(env_name)
       pytest --cov obsplus && pytest --nbval docs/
-    displayName: pytest
+    displayName: run test suite
 
+  - bash: |
+      source activate $(env_name)
+      pytest --cov obsplus && pytest --nbval docs/
+    displayName: test docstring examples
+
+  - bash: |
+      source activate $(env_name)
+      pytest --nbval docs/
+    displayName: test documentation
 
 - job: 'macOS'
   pool:
@@ -96,7 +105,17 @@ jobs:
   - bash: |
       source activate $(env_name)
       pytest --cov obsplus && pytest --nbval docs/
-    displayName: pytest
+    displayName: run test suite
+
+  - bash: |
+      source activate $(env_name)
+      pytest --cov obsplus && pytest --nbval docs/
+    displayName: test docstring examples
+
+  - bash: |
+      source activate $(env_name)
+      pytest --nbval docs/
+    displayName: test documentation
 
 #
 #- job: 'windows'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,23 +46,23 @@ jobs:
     displayName: Create Anaconda environment
 
   - bash: |
-        source activate $(env_name)
-        flake8
+      source activate $(env_name)
+      flake8
     displayName: flake8
 
   - bash: |
       source activate $(env_name)
-      pytest --cov obsplus && pytest --nbval docs/
+      pytest --cov obsplus
     displayName: run test suite
 
   - bash: |
       source activate $(env_name)
-      pytest --cov obsplus && pytest --nbval docs/
+      pytest obsplus --doctest-modules
     displayName: test docstring examples
 
   - bash: |
       source activate $(env_name)
-      pytest --nbval docs/
+      pytest docs --nbval
     displayName: test documentation
 
 - job: 'macOS'
@@ -104,17 +104,17 @@ jobs:
 
   - bash: |
       source activate $(env_name)
-      pytest --cov obsplus && pytest --nbval docs/
+      pytest --cov obsplus
     displayName: run test suite
 
   - bash: |
       source activate $(env_name)
-      pytest --cov obsplus && pytest --nbval docs/
+      pytest obsplus --doctest-modules
     displayName: test docstring examples
 
   - bash: |
       source activate $(env_name)
-      pytest --nbval docs/
+      pytest docs --nbval
     displayName: test documentation
 
 #

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -181,8 +181,11 @@ def make_time_chunks(
     ----------
     >>> t1 = obspy.UTCDateTime('2016-01-01')
     >>> t2 = t1 + 3 * 3600
-    >>> out = make_time_chunks(t1, t2, 3600)
-    >>> assert out == [t1, t1 + 3600, t2]
+    >>> out = list(make_time_chunks(t1, t2, 3600))
+    >>> assert len(out) == 3
+    >>> assert out[0] == (t1, t1 + 3600)
+    >>> assert out[1] == (t1 + 3600, t1 + 3600 * 2)
+    >>> assert out[2] == (t1 + 3600 * 2, t1 + 3600 * 3)
     """
     utc1 = to_utc(utc1)
     utc2 = to_utc(utc2)


### PR DESCRIPTION
This PR refactors the azure pipelines config file to split up documentation tests and running the test suite into separate steps. It also adds a step for running docstring examples, although there aren't many (yet). 