### PR TITLE
more flexible input for get_distance_df

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ obsplus master:
       misinterpreted by pandas (see #130 and #132).
   - obsplus.utils
     * Deprecate get_nslc_series in favor of get_seed_id_series (#120).
+    * get_distance_df now allows dataframes as inputs (#154).
   - obsplus.validate
     * Added the obsplus.validate module which contains a simple framework for
       defining and running validators on python objects. Replaced the old

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,11 +52,6 @@ jobs:
 
   - bash: |
       source activate $(env_name)
-      pytest --cov obsplus && pytest --nbval docs/
-    displayName: run test suite
-
-  - bash: |
-      source activate $(env_name)
       pytest --cov obsplus
     displayName: run test suite
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
   - bash: |
         source activate $(env_name)
         flake8
-      displayName: flake8
+    displayName: flake8
 
   - bash: |
       source activate $(env_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -442,6 +442,19 @@ class TestDistanceDataframe:
         combinations = set(itertools.permutations(event_ids, 2))
         assert combinations == set(df.index)
 
+    def test_dataframe_input(self, cat):
+        """
+        Any dataframe should be valid input provided it has the required columns.
+        """
+        data = [[10.1, 10.1, 0, "some_id"]]
+        cols = ["latitude", "longitude", "elevation", "id"]
+        df = pd.DataFrame(data, columns=cols)
+        dist_df = get_distance_df(df, cat)
+        # make sure output has expected shape and ids
+        assert len(dist_df) == len(cat) * len(df)
+        id1 = dist_df.index.get_level_values("id1")
+        assert "some_id" in set(id1)
+
 
 class TestMD5:
     """ Tests for getting md5 hashes from files. """


### PR DESCRIPTION
This PR allows users to pass a dataframe with the required columns ('latitude', 'longitude', 'elevation', 'id') to `get_distance_df` rather than just obspy-like objects such as `Catalog` or `Inventory`.