### PR TITLE
add dynamic support for abc classes

### DIFF
--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -41,9 +41,12 @@ class _MethodChecker(type):
 
     def __instancecheck__(cls, instance):
         is_instance = not inspect.isclass(instance)
+        # look for defined methods
         if is_instance and set(cls._required_methods).issubset(dir(instance)):
             return True
-        return False
+        # if they do not exist probe for dynamic methods  that meet criteria
+        has_meths = [getattr(instance, x, False) for x in cls._required_methods]
+        return all(has_meths) and is_instance
 
 
 class EventClient(metaclass=_MethodChecker):

--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -11,6 +11,7 @@ import obspy
 import pandas as pd
 from obspy import Stream, UTCDateTime
 
+import obsplus
 from obsplus import events_to_df, stations_to_df, picks_to_df
 from obsplus.bank.wavebank import WaveBank
 from obsplus.constants import (
@@ -74,8 +75,8 @@ def _temporary_override(func):
 
 # ---------------------------------- Wavefetcher class
 
-fetcher_waveform_type = waveform_clientable_type
-fetcher_event_type = Union[event_clientable_type, pd.DataFrame]
+fetcher_waveform_type = Union[waveform_clientable_type, obsplus.WaveBank]
+fetcher_event_type = Union[event_clientable_type, pd.DataFrame, obsplus.EventBank]
 fetcher_station_type = Union[station_clientable_type, pd.DataFrame]
 
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -10,6 +10,16 @@ from obsplus import EventBank, WaveBank
 from obsplus.interfaces import EventClient, WaveformClient, StationClient, ProgressBar
 
 
+class DynamicWrapper:
+    """ Simple wrapper for an object. """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __getattr__(self, item):
+        return getattr(self.obj, item)
+
+
 # fixtures
 
 
@@ -23,6 +33,8 @@ def iris_client():
 
 
 class TestEventClient:
+    not_event_client_instances = ["a", 1, EventBank]
+
     def test_fdsn_isinstance(self, iris_client):
         """ ensure the client is an instance of EventClient """
         assert isinstance(iris_client, EventClient)
@@ -43,6 +55,16 @@ class TestEventClient:
         ebank = EventBank(bingham_dataset.event_path)
         assert isinstance(ebank, EventClient)
         assert issubclass(EventBank, EventClient)
+
+    def test_dynamic_client(self, bingham_dataset):
+        """ Ensure dynamic instances work. """
+        event_client = DynamicWrapper(bingham_dataset.event_client)
+        assert isinstance(event_client, EventClient)
+
+    @pytest.mark.parametrize("not_client", not_event_client_instances)
+    def test_not_instances(self, not_client):
+        """ Ensure a few negative examples work. """
+        assert not isinstance(not_client, EventClient)
 
 
 class TestWaveformClient:
@@ -65,6 +87,11 @@ class TestWaveformClient:
         assert isinstance(wavebank, WaveformClient)
         assert issubclass(WaveBank, WaveformClient)
 
+    def test_dynamic_client(self, bingham_dataset):
+        """ Ensure dynamic instances work. """
+        waveform_client = DynamicWrapper(bingham_dataset.waveform_client)
+        assert isinstance(waveform_client, WaveformClient)
+
 
 class TestStationClient:
     def test_fdsn_isinstance(self, iris_client):
@@ -80,6 +107,11 @@ class TestStationClient:
         inv = obspy.read_inventory()
         assert isinstance(inv, StationClient)
         assert issubclass(obspy.Inventory, StationClient)
+
+    def test_dynamic_client(self, bingham_dataset):
+        """ Ensure dynamic instances work. """
+        station_client = DynamicWrapper(bingham_dataset.station_client)
+        assert isinstance(station_client, StationClient)
 
 
 class TestBar:

--- a/tests/test_structures/test_fetcher.py
+++ b/tests/test_structures/test_fetcher.py
@@ -151,9 +151,8 @@ class TestGeneric:
 
     def test_init_with_banks(self, bingham_dataset):
         """ Ensure the fetcher can be init'ed with all bank inputs. """
-        wbank = obsplus.WaveBank(bingham_dataset.waveform_path)
-        ebank = obsplus.EventBank(bingham_dataset.event_path)
-        wbank.update_index(), ebank.update_index()
+        wbank = obsplus.WaveBank(bingham_dataset.waveform_path).update_index()
+        ebank = obsplus.EventBank(bingham_dataset.event_path).update_index()
         sbank = bingham_dataset.station_client
         fetcher = Fetcher(waveforms=wbank, events=ebank, stations=sbank)
         edf = fetcher.event_df


### PR DESCRIPTION
This PR makes the is instance checks on the ABCs defined in `obspy.interfaces` more flexible. Specifically, if the required methods aren't present from calling `dir` on a candidate instance they will be searched for specifically. This handles the case that they are returned dynamically from `__getattr__`. 

This change is more for obsplus' internals and should have little effect on any users.   