### PR TITLE
Udpate index subpaths

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,12 @@ obsplus master:
       memory during indexing (see #136 and #137).
     * WaveBank.get_gaps_df now accounts for small overlapping file which
       previously caused false gaps to be reported (see #140).
+    * Added paths parameter to update_index methods to speed up indexing when
+      file locations are predictable (see #144).
+    * Removed print statement which fired every time the index of a bank  was
+      created or updated (see #144).
+    * Updated put_x methods to only index newly added files when update_index
+      is True. First mentioned in (#122), implemented in (#144).
   - obsplus.interfaces
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -135,10 +135,15 @@ class _Bank(ABC):
         if last_updated is not None:
             mtime = last_updated - 0.001
         # get paths to iterate
+        bank_path = self.bank_path
         if sub_paths is None:
             paths = self.bank_path
         else:
-            paths = [f"{self.bank_path}/{x}" for x in iterate(sub_paths)]
+            # TODO move this to bank utils
+            paths = [
+                f"{self.bank_path}/{x}" if str(bank_path) not in str(x) else str(x)
+                for x in iterate(sub_paths)
+            ]
         # return file iterator
         return iter_files(paths, ext=self.ext, mtime=mtime)
 
@@ -205,7 +210,6 @@ class _Bank(ABC):
         If bar is a subclass of ProgressBar, init class and set max_values.
         If bar is an instance of ProgressBar, return it.
         """
-        print(f"updating or creating event index for {self.bank_path}")
         # conditions to bail out early
         if bar is False:  # False indicates no bar is to be used
             return None

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -34,6 +34,8 @@ from obsplus.constants import (
     bar_parameter_description,
     EVENT_TYPES_OUTPUT,
     EVENT_TYPES_INPUT,
+    bank_subpaths_type,
+    subpaths_description,
 )
 from obsplus.events.get_events import _sanitize_circular_search, _get_ids
 from obsplus.exceptions import BankDoesNotExistError
@@ -207,14 +209,22 @@ class EventBank(_Bank):
             df = df[df.event_id.isin(circular_ids)]
         return df
 
-    @compose_docstring(bar_paramter_description=bar_parameter_description)
-    def update_index(self, bar: Optional[ProgressBar] = None) -> "EventBank":
+    @compose_docstring(
+        bar_description=bar_parameter_description,
+        subpaths_description=subpaths_description,
+    )
+    def update_index(
+        self,
+        bar: Optional[ProgressBar] = None,
+        sub_paths: Optional[bank_subpaths_type] = None,
+    ) -> "EventBank":
         """
         Iterate files in bank and add any modified since last update to index.
 
         Parameters
         ----------
         {bar_parameter_description}
+        {subpaths_description}
         """
 
         def func(path):
@@ -228,7 +238,7 @@ class EventBank(_Bank):
         # create iterator  and lists for storing output
         update_time = time.time()
         # create an iterator which yields files to update and updates bar
-        update_file_feeder = self._measured_unindexed_iterator(bar)
+        update_file_feeder = self._measured_unindexed_iterator(bar, sub_paths)
         # create iterator, loop over it in chunks util it is exhausted
         iterator = self._map(func, update_file_feeder)
         events_remain = True

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -40,6 +40,7 @@ from obsplus.constants import (
     WAVEFORM_DTYPES_INPUT,
     EMPTYTD64,
     bank_subpaths_type,
+    subpaths_description,
 )
 from obsplus.utils import (
     compose_docstring,
@@ -196,7 +197,10 @@ class WaveBank(_Bank):
             data_columns=list(self.index_ints),
         )
 
-    @compose_docstring(bar_paramter_description=bar_parameter_description)
+    @compose_docstring(
+        bar_description=bar_parameter_description,
+        subpaths_description=subpaths_description,
+    )
     def update_index(
         self, bar: Optional = None, sub_paths: Optional[bank_subpaths_type] = None
     ) -> "WaveBank":
@@ -205,12 +209,8 @@ class WaveBank(_Bank):
 
         Parameters
         ----------
-        {bar_parameter_description}
-        sub_paths
-            A str, or iterable of str, specifying subdirectories (relative
-            to bank path)to allow updating only files in sud directories
-            of the bank. This is useful for large banks which
-            have files added to them in predictable locations.
+        {bar_description}
+        {subpaths_description}
         """
         self._enforce_min_version()  # delete index if schema has changed
         update_time = time.time()

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -669,3 +669,13 @@ bar
     If a custom progress bar is to be used, it must have an `update`
     and `finish` method.
 """
+
+subpaths_description = """
+sub_paths
+    A str, or iterable of str, specifying subdirectories (relative
+    to bank path) to allow updating only files in specific directories
+    of the bank. This is useful for large banks which have files added
+    to them in predictable locations. However, if other files are added
+    outside of these locations they may not get indexed as the last updated
+    timestamp still gets updated (use with caution).
+"""

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
     TypeVar,
     MutableSequence,
+    Iterable,
 )
 
 import numpy as np
@@ -445,6 +446,9 @@ series_func_type = Callable[[pd.Series], Union[pd.Series, np.ndarray]]
 
 # type for mapping of functions to apply over callables
 column_function_map_type = Mapping[str, series_func_type]
+
+# subpaths type
+bank_subpaths_type = Union[str, Iterable[str]]
 
 # -------------------------- events validation constants
 

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -670,12 +670,12 @@ bar
     and `finish` method.
 """
 
-subpaths_description = """
+paths_description = """
 sub_paths
     A str, or iterable of str, specifying subdirectories (relative
     to bank path) to allow updating only files in specific directories
     of the bank. This is useful for large banks which have files added
     to them in predictable locations. However, if other files are added
-    outside of these locations they may not get indexed as the last updated
-    timestamp still gets updated (use with caution).
+    outside of these locations they may not get indexed as the banks timestamp
+    indicating the last time of indexing will still get updated.
 """

--- a/obsplus/utils.py
+++ b/obsplus/utils.py
@@ -822,6 +822,8 @@ def iter_files(
     except TypeError:  # multiple paths were passed
         for path in paths:
             yield from iter_files(path, ext, mtime, skip_hidden)
+    except NotADirectoryError:  # a file path was passed, just return it
+        yield paths
 
 
 def get_distance_df(

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -272,6 +272,16 @@ class TestBankBasics:
         np_datetime_cols = df.select_dtypes(np.datetime64).columns
         assert {"starttime", "endtime"}.issubset(np_datetime_cols)
 
+    def test_update_index_with_subpaths(self, ta_bank_no_index):
+        """ Ensure update index can have subpaths passed to it. """
+        bank = ta_bank_no_index
+        # get sub paths to excluse Z components
+        sub_paths = "TA/M11A/VHE", "TA/M11A/VHN"
+        bank.update_index(sub_paths=sub_paths)
+        # make sure only VHE and VHN are in index
+        df = bank.read_index()
+        assert set(df["channel"].unique()) == {"VHE", "VHN"}
+
 
 class TestEmptyBank:
     """ tests for graceful handling of empty sbanks"""
@@ -1277,8 +1287,9 @@ class TestConcurrentUpdateIndex:
 
     # tests
     def test_index_read_thread(self, thread_read):
-        """ ensure the index updated and the threads didn't kill each
-        other """
+        """
+        Ensure the index updated and the threads didn't kill each other.
+        """
         # get a list of exceptions that occurred
         assert len(thread_read) == self.worker_count
         excs = [x.result() for x in thread_read]


### PR DESCRIPTION
This PR adds a `sub_paths` argument to both `EventBank.update_index` and `WaveBank.update_index`. It can be useful to avoid iterating all the files in a large bank when new files are added predictably (ie based on time).

What do you think about this @sboltz ?