### PR TITLE
Change default chunksize

### DIFF
--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -262,7 +262,7 @@ class _Bank(ABC):
             return getattr(executor, "_max_workers", CPU_COUNT)
         return 1
 
-    def _map(self, func, args, chunksize=None):
+    def _map(self, func, args, chunksize=1):
         """
         Map the args to function, using executor if defined else perform
         in serial.


### PR DESCRIPTION
The default for `_map` for `chunksize=None` resulted in an error when using a `ProcessPoolExecutor` - the default for these is `1` (it isn't clear from [the docs](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.map) that this has to be an int, but the error occurs when comparing to an int).