### PR TITLE
Concurrent maps

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,8 @@ obsplus master:
     * Removed `concurrent_updates` and `inventory` argument from `WaveBank`.
       see (#147 and #152)
     * The `updated` column in wavebank is now correct (see #146, #147).
+    * Fixed issue with using `ProcessPoolExecutor` in EventBank for `put_event`
+      and `update_index` (see issues #158, #159, #161).
   - obsplus.interfaces
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the

--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -173,9 +173,7 @@ class _Bank(ABC):
         # return file iterator
         return iter_files(paths, ext=self.ext, mtime=mtime)
 
-    def _measure_iterator(
-        self, iterable: Iterable, bar: Optional[ProgressBar] = None, include_args=None
-    ):
+    def _measure_iterator(self, iterable: Iterable, bar: Optional[ProgressBar] = None):
         """
         A generator to yield un-indexed files and update progress bar.
 
@@ -185,10 +183,6 @@ class _Bank(ABC):
             Any iterable to yield.
         bar
             Any object which has a 'update' method.
-        include_args
-            A tuple of objects which should also be yielded with each
-            value of iterable.
-            This is a bit of a hack to avoid issues mentioned in #158.
         """
         # get progress bar
         bar = self.get_progress_bar(bar)
@@ -197,10 +191,7 @@ class _Bank(ABC):
             # update bar if count is in update interval
             if bar is not None and num % self._bar_update_interval == 0:
                 bar.update(num)
-            if include_args is not None:
-                yield (obj, *include_args)
-            else:
-                yield obj
+            yield obj
         # finish progress bar
         getattr(bar, "finish", lambda: None)()  # call finish if bar exists
 

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -703,7 +703,7 @@ class WaveBank(_Bank):
         kwargs = dict(format=self.format, starttime=starttime, endtime=endtime)
         func = partial(_try_read_stream, **kwargs)
         stt = obspy.Stream()
-        chunksize = len(files) / self._max_workers
+        chunksize = (len(files) // self._max_workers) or 1
         for st in self._map(func, files, chunksize=chunksize):
             if st is not None:
                 stt += st

--- a/obsplus/utils/testing.py
+++ b/obsplus/utils/testing.py
@@ -19,7 +19,7 @@ from obsplus.utils.time import make_time_chunks, to_utc
 @contextmanager
 def instrument_methods(obj):
     """
-    Temporarily instrument an objects methods.
+    Temporarily instrument an object's methods.
 
     This allows the calls to each of the objects methods to be counted.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,8 +224,8 @@ def thread_executor():
 
 @pytest.fixture(scope="class")
 def process_executor():
-    """ return a thread pool """
-    # in order to avoid sapping too many resources, just use
+    """ return a process pool """
+    # in order to avoid sapping too many resources, just use 1/2 CPU count
     with ProcessPoolExecutor((CPU_COUNT // 2)) as executor:
         yield executor
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import glob
 import os
 import shutil
 import typing
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from os.path import basename
 from os.path import join, dirname, abspath
 from pathlib import Path
@@ -222,26 +222,32 @@ def thread_executor():
         yield executor
 
 
+@pytest.fixture(scope="class")
+def process_executor():
+    """ return a thread pool """
+    # in order to avoid sapping too many resources, just use
+    with ProcessPoolExecutor((CPU_COUNT // 2)) as executor:
+        yield executor
+
+
+@pytest.fixture(scope="class", params=["thread", "process"])
+def executor(request):
+    """Aggregate both the thread and process executors."""
+    fixture_name = f"{request.param}_executor"
+    return request.getfixturevalue(fixture_name)
+
+
 @pytest.fixture()
-def instrumented_thread_executor(thread_executor):
+def instrumented_executor(executor):
     """
     Return a thread pool executor which has been instrumented.
 
     This allows the calls to each of the executors methods to be counted. A
     Counter object is attached to the executor and each of the methods is
     wrapped to count how many times it is called.
-
-
-    Parameters
-    ----------
-    thread_executor
-
-    Returns
-    -------
-
     """
-    with instrument_methods(thread_executor):
-        yield thread_executor
+    with instrument_methods(executor):
+        yield executor
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -91,11 +91,6 @@ def ebank_with_bad_files(tmpdir):
     st.write(str(stream_path / "not_an_event.xml"), "mseed")
     bank = EventBank(stream_path)
     # should issue warning
-
-    # bank.index_path.unlink()
-    # breakpoint()
-    # bank.update_index()
-
     with pytest.warns(UserWarning):
         bank.update_index()
     return bank

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -687,24 +687,39 @@ class TestConcurrency:
     """ Tests for using an executor for concurrency. """
 
     @pytest.fixture
-    def ebank_executor(self, ebank, instrumented_thread_executor, monkeypatch):
+    def ebank_thread_exec(self, ebank, instrumented_executor, monkeypatch):
         """ Attach the instrument threadpool executor to ebank. """
-        monkeypatch.setattr(ebank, "executor", instrumented_thread_executor)
+        monkeypatch.setattr(ebank, "executor", instrumented_executor)
         return ebank
 
-    def test_executor_get_events(self, ebank_executor):
+    @pytest.fixture
+    def new_catalog(self):
+        """Change the resource ids of events in the default catalog, return."""
+        cat = obspy.read_events()
+        for event in cat:
+            event.resource_id = ev.ResourceIdentifier()
+        return cat
+
+    def test_executor_get_events(self, ebank_thread_exec):
         """ Ensure the threadpool map function is used for reading events. """
         # get events, ensure map is used
-        _ = ebank_executor.get_events()
-        counter = getattr(ebank_executor.executor, "_counter", {})
+        _ = ebank_thread_exec.get_events()
+        counter = getattr(ebank_thread_exec.executor, "_counter", {})
         assert counter.get("map", 0) == 1
 
-    def test_executor_index_events(self, ebank_executor):
+    def test_executor_index_events(self, ebank_thread_exec):
         """ Ensure threadpool map is used for updating the index. """
         try:
-            os.remove(ebank_executor.index_path)
+            os.remove(ebank_thread_exec.index_path)
         except FileNotFoundError:
             pass
-        ebank_executor.update_index()
-        counter = getattr(ebank_executor.executor, "_counter", {})
+        ebank_thread_exec.update_index()
+        counter = getattr(ebank_thread_exec.executor, "_counter", {})
         assert counter.get("map", 0) == 1
+
+    def test_put_events(self, ebank_thread_exec, new_catalog):
+        """Ensure putting events doesn't raise and increments event count."""
+        count_before = len(ebank_thread_exec.read_index())
+        ebank_thread_exec.put_events(new_catalog)
+        count_after = len(ebank_thread_exec.read_index())
+        assert count_after == count_before + len(new_catalog)

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1219,9 +1219,9 @@ class TestConcurrentReads:
     """
 
     @pytest.fixture
-    def wbank_executor(self, ta_bank, monkeypatch, instrumented_thread_executor):
+    def wbank_executor(self, ta_bank, monkeypatch, instrumented_executor):
         """ Return a wavebank with an instrumented executor. """
-        monkeypatch.setattr(ta_bank, "executor", instrumented_thread_executor)
+        monkeypatch.setattr(ta_bank, "executor", instrumented_executor)
         with suppress(FileNotFoundError):
             os.remove(ta_bank.index_path)
         return ta_bank


### PR DESCRIPTION
This PR address #158, also ensures proper values of `chunksize` are selected (as in #159).

It includes testing with `ProcessPoolExecutor` now rather than just `ThreadPoolExecutor`. 

The solution is a bit messy, any suggestions for improvement welcomed.

