### PR TITLE
EventBank multiple-event files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,8 @@ obsplus master:
     * The `updated` column in wavebank is now correct (see #146, #147).
     * Fixed issue with using `ProcessPoolExecutor` in EventBank for `put_event`
       and `update_index` (see issues #158, #159, #161).
+    * Fixed bug where an EventBank with files containing multiple events would
+      duplicate events in the catalog on `get_events`. (See #166).
   - obsplus.interfaces
     * Added ProgressBar for defining classes compatible with how obsplus
       uses progress bar, modeled after the ProgressBar class from the

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -387,8 +387,8 @@ class EventBank(_Bank):
         """
         ind = self.read_index(**kwargs)
         eids = ind["event_id"]
-        files_paths = ind["path"]
-        paths = str(self.bank_path) + _natify_paths(files_paths)
+        file_paths = ind["path"]
+        paths = str(self.bank_path) + _natify_paths(file_paths)
         paths.drop_duplicates(inplace=True)
         read_func = partial(try_read_catalog, format=self.format)
         # Divide work evenly between workers, with a min chunksize of 1.
@@ -400,11 +400,7 @@ class EventBank(_Bank):
         except TypeError:  # empty events
             cat = obspy.Catalog()
         # Make sure only the events of interest are included
-        cat1 = obspy.Catalog()
-        for eve in cat:
-            if eve.resource_id.id in eids:
-                cat1.append(eve)
-        return cat1
+        return obspy.Catalog([eve for eve in cat if eve.resource_id.id in eids.values])
 
     def ids_in_bank(self, event_id: Union[str, Sequence[str]]) -> Set[str]:
         """

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -401,8 +401,9 @@ class EventBank(_Bank):
             cat = obspy.Catalog()
         # Make sure only the events of interest are included
         cat1 = obspy.Catalog()
-        for eid in eids:
-            cat1.append(ev.ResourceIdentifier(eid).get_referred_object())
+        for eve in cat:
+            if eve.resource_id.id in eids:
+                cat1.append(eve)
         return cat1
 
     def ids_in_bank(self, event_id: Union[str, Sequence[str]]) -> Set[str]:

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -174,7 +174,9 @@ class _IndexCache:
         con3 = self.cache.kwargs == self._kwargs_to_str(kwargs)
         cached_index = self.cache[con1 & con2 & con3]
         if not len(cached_index):  # query is not cached get it from hdf5 file
-            where = _get_kernel_query(int(starttime), int(endtime), int(buffer))
+            where = _get_kernel_query(
+                starttime.astype(np.int64), endtime.astype(np.int64), int(buffer)
+            )
             raw_index = self._get_index(where, **kwargs)
             # replace "None" with None
             ic = self.bank.index_str

--- a/obsplus/utils/time.py
+++ b/obsplus/utils/time.py
@@ -164,9 +164,13 @@ def to_datetime64(
             return to_datetime64(default)
         return default
     elif isinstance(value, np.datetime64):
-        return value
+        # The '.astype('datetime64[ns]') is necessary to make sure it really
+        # does get converted to nanoseconds
+        return value.astype("datetime64[ns]")
     elif isinstance(value, pd.Timestamp):
-        return value.to_datetime64()
+        # The '.astype('datetime64[ns]') is necessary to make sure it really
+        # does get converted to nanoseconds
+        return value.to_datetime64().astype("datetime64[ns]")
     try:
         utc = obspy.UTCDateTime(value)
         return np.datetime64(utc._ns, "ns")

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -465,6 +465,14 @@ class TestReadIndexQueries:
 class TestGetEvents:
     """ tests for pulling events out of the bank """
 
+    @pytest.fixture
+    def multiple_event_file(self, tmp_path_factory, crandall_dataset):
+        """ Create a bank from a single file with multiple events """
+        path = tmp_path_factory.mktemp("crandall_bank")
+        cat_name = path / "event_bank.xml"
+        crandall_dataset.event_client.write(cat_name, "QuakeML")
+        return EventBank(path)
+
     def test_no_params(self, bing_ebank, bingham_catalog):
         """ ensure a basic query can get an event """
         cat = bing_ebank.get_events()
@@ -505,6 +513,16 @@ class TestGetEvents:
         inds = ebank.read_index()["event_id"].values[0:2]
         # query with inds as np array
         assert len(ebank.get_events(eventid=np.array(inds))) == 2
+
+    def test_multiple_event_file(self, multiple_event_file):
+        """
+        Make sure a catalog file with multiple events is handled appropriately
+        """
+        minmag = 2.0
+        # Get the events; add a query for good measure
+        assert len(multiple_event_file.get_events(minmagnitude=minmag)) == 3
+
+
 
 
 class TestPutEvents:

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -523,8 +523,6 @@ class TestGetEvents:
         assert len(multiple_event_file.get_events(minmagnitude=minmag)) == 3
 
 
-
-
 class TestPutEvents:
     """ tests for putting events into the bank """
 


### PR DESCRIPTION
This PR fixes a bug where EventBank would duplicate the events that were returned during `get_events` if a file in the bank contained multiple events. Additionally, it makes sure that files that contain multiple events are filtered appropriately before returning events.