### PR TITLE
Fetcher._get_bulk_args bugfix

### DIFF
--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -515,8 +515,13 @@ class Fetcher:
         df = inv[~(con1 | con2)].set_index("seed_id")[list(NSLC)]
         if df.empty:  # return empty list if no data found
             return []
-        df["starttime"] = starttime
-        df["endtime"] = endtime
+        if isinstance(starttime, pd.Series):
+            # Have to get clever here to make sure only active stations get used
+            df["starttime"] = starttime.loc[set(starttime.index).intersection(df.index)]
+            df["endtime"] = endtime.loc[set(endtime.index).intersection(df.index)]
+        else:
+            df["starttime"] = starttime
+            df["endtime"] = endtime
         # remove any rows that don't have defined start/end times
         out = df[~(df["starttime"].isnull() | df["endtime"].isnull())]
         # ensure we have UTCDateTime objects

--- a/tests/test_structures/test_fetcher.py
+++ b/tests/test_structures/test_fetcher.py
@@ -390,6 +390,18 @@ class TestYieldEventWaveforms:
         )
         return Fetcher(**kwargs)
 
+    # @pytest.fixture(scope="class")
+    # def fetcher_inactive_stations(self, bingham_dataset):
+    #     """ Init wavefetcher with one event that starts after some stations end """
+    #     event = bingham_dataset.event_client.get_events()[-1]
+    #     event.preferred_origin().time = obspy.UTCDateTime(2013, 6, 1)
+    #     kwargs = dict(
+    #         waveforms=bingham_dataset.waveform_client,
+    #         events=event,
+    #         stations=bingham_dataset.station_client.get_stations(),
+    #     )
+    #     return Fetcher(**kwargs)
+
     # general test
 
     def test_duration(self, stream_dict):


### PR DESCRIPTION
This pull request fixes a bug where `Fetcher._get_bulk_args` will fail if starttime or endtime are `pd.Series` that contain scnls in the index that were not active at the time.