### PR TITLE
create inv location code 00

### DIFF
--- a/obsplus/utils/stations.py
+++ b/obsplus/utils/stations.py
@@ -130,7 +130,7 @@ def df_to_inventory(df) -> obspy.Inventory:
 
     # make sure all seed_id codes are str
     for col in set(NSLC) & set(df.columns):
-        df[col] = df[col].astype(str).str.replace(".0", "")
+        df[col] = df[col].astype(str).str.replace("\.0", "")
     # first get key_mappings
     net_map = _make_key_mappings(Network)
     sta_map = _make_key_mappings(Station)

--- a/tests/test_utils/test_stations_utils.py
+++ b/tests/test_utils/test_stations_utils.py
@@ -182,3 +182,11 @@ class TestDfToInventory:
         inv = df_to_inventory(df)
         for net in inv:
             assert not net.stations
+
+    def test_00_location_code(self, df_from_inv):
+        """Ensure a 00 location code sticks until the inventory."""
+        df = df_from_inv.copy()
+        df["location"] = "00"
+        inv = df_to_inventory(df)
+        for channel in inv.get_contents()["channels"]:
+            assert channel.split(".")[2] == "00"


### PR DESCRIPTION
Fixes a small bug in creating an inventory from a dataframe which would silently drop '00' location codes.