### PR TITLE
Circular search with no events in region fails.

### DIFF
--- a/obsplus/events/get_events.py
+++ b/obsplus/events/get_events.py
@@ -90,7 +90,7 @@ def _get_ids(df, kwargs) -> set:
         kwargs.update(_get_bounding_box(circular_kwargs))
         df = get_event_summary(df, **kwargs)
         if len(df) == 0:  # If there are no events in the rectangular region.
-            return {}
+            return set()
         filt = np.ones(len(df)).astype(bool)
         # Trim based on circular kwargs, first get distance dataframe.
         input = (circular_kwargs["latitude"], circular_kwargs["longitude"], 0)

--- a/obsplus/events/get_events.py
+++ b/obsplus/events/get_events.py
@@ -89,6 +89,8 @@ def _get_ids(df, kwargs) -> set:
         # Circular kwargs are used, first apply non-circular query then trim
         kwargs.update(_get_bounding_box(circular_kwargs))
         df = get_event_summary(df, **kwargs)
+        if len(df) == 0:  # If there are no events in the rectangular region.
+            return {}
         filt = np.ones(len(df)).astype(bool)
         # Trim based on circular kwargs, first get distance dataframe.
         input = (circular_kwargs["latitude"], circular_kwargs["longitude"], 0)

--- a/tests/test_events/test_get_events.py
+++ b/tests/test_events/test_get_events.py
@@ -86,6 +86,13 @@ class TestGetEvents:
         # For the example catalog there should be exactly 2 events included
         assert len(cat) == 2
 
+    def test_circular_search_no_events(self, catalog):
+        """ Ensure no errors if no events within rectangular region. #177 """
+        lat, lon = 31.0, 30.0
+        with suppress_warnings():
+            cat = catalog.get_events(latitude=lat, longitude=lon, maxradius=1)
+        assert len(cat) == 0
+
     def test_max_min_radius_m(self, catalog):
         """ Ensure max and min radius work in m (ie when degrees=False). """
         minrad = 10000


### PR DESCRIPTION
Circular search in `obsplus.get_events.get_events` returns an error if no events are within the rectangular region (defined to bound the circular region for speed-ups).

This PR adds a check to see if the rectangular search returns an empty dataframe and immediately returns an empty 'set' if this is the case.

## TODO:
- [x] Add a simple testcase for this (currently only checked by me locally using a larger catalog that yielded the error initially).