### PR TITLE
Allow blank string for path_structure (#178)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,12 @@ Master
       name but different networks (#173).
     * Added `subset` parameter to `get_seed_id_series` for selecting subsets
       of full seed id.
+  - obsplus.EventBank
+    * Fixed issue where path_structure was overriding a user-specified value
+      of `""` (#178)
+  - obsplus.WaveBank
+    * Fixed issue where path_structure was overriding a user-specified value
+      of `""` (#178)
 
 obsplus 0.1.0:
   - obsplus.structures.fetcher

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -168,7 +168,11 @@ class EventBank(_Bank):
         self.format = format
         self.ext = ext
         # get waveforms structure based on structures of path and filename
-        ps = path_structure or self._path_structure or EVENT_PATH_STRUCTURE
+        ps = (
+            path_structure
+            if path_structure is not None
+            else (self._path_structure or EVENT_PATH_STRUCTURE)
+        )
         self.path_structure = ps
         ns = name_structure or self._name_structure or EVENT_NAME_STRUCTURE
         self.name_structure = ns

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -183,7 +183,9 @@ class WaveBank(_Bank):
         self.ext = ext
         self.bank_path = Path(base_path).absolute()
         # get waveforms structure based on structures of path and filename
-        self.path_structure = path_structure or WAVEFORM_STRUCTURE
+        self.path_structure = (
+            path_structure if path_structure is not None else WAVEFORM_STRUCTURE
+        )
         self.name_structure = name_structure or WAVEFORM_NAME_STRUCTURE
         self.executor = executor
         # initialize cache

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -122,7 +122,7 @@ def _summarize_trace(
     out.update(_get_time_values(t1, t2))
     out.update(dict((x, c) for x, c in zip(NSLC, trace.id.split("."))))
 
-    path_struct = path_struct or WAVEFORM_STRUCTURE
+    path_struct = path_struct if path_struct is not None else WAVEFORM_STRUCTURE
     name_struct = name_struct or WAVEFORM_NAME_STRUCTURE
 
     out.update(_get_path(out, path, name, path_struct, name_struct))

--- a/obsplus/utils/events.py
+++ b/obsplus/utils/events.py
@@ -590,7 +590,7 @@ def _summarize_event(
     }
     t1 = _get_event_origin_time(event)
     out.update(_get_time_values(t1))
-    path_struct = path_struct or EVENT_PATH_STRUCTURE
+    path_struct = path_struct if path_struct is not None else EVENT_PATH_STRUCTURE
     name_struct = name_struct or EVENT_NAME_STRUCTURE
     out.update(_get_path(out, path, name, path_struct, name_struct))
     return out

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -340,6 +340,14 @@ class TestBankBasics:
         sensible_start = np.datetime64("2000-01-01T01:00:00")
         assert (df["updated"] > sensible_start).all()
 
+    def test_path_structure(self, tmpdir):
+        """
+        Ensure that it is possible to not use a path structure (see #178)
+        """
+        path = Path(tmpdir) / "path_structure"
+        bank = EventBank(path, path_structure="")
+        assert bank.path_structure == ""
+
 
 class TestEventIdInBank:
     """ Tests for determining if ids are in the bank. """

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -286,6 +286,14 @@ class TestBankBasics:
         expected_order = expected_order_1 + expected_order_2
         assert [str(x) for x in df.columns] == list(expected_order)
 
+    def test_path_structure(self, tmpdir):
+        """
+        Ensure that it is possible to not use a path structure (see #178)
+        """
+        path = Path(tmpdir) / "path_structure"
+        bank = WaveBank(path, path_structure="")
+        assert bank.path_structure == ""
+
 
 class TestEmptyBank:
     """ tests for graceful handling of empty WaveBanks"""


### PR DESCRIPTION
This PR addresses issue #178, where using a blank string for  the path_structure (effectively indicating no path structure) was being overwritten during initialization of an EventBank (this also applied to WaveBank).