### PR TITLE
Fix duplicate channel df to inv issue

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,9 @@ Master
   - obsplus.WaveBank
     * Fixed issue where path_structure was overriding a user-specified value
       of `""` (#178)
+  - obsplus.structures.fetcher
+    * fixed issue with Fetcher raising Pandas error when an inventory with
+      duplicate chanenls was used (#183, #184).
 
 obsplus 0.1.0:
   - obsplus.structures.fetcher

--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -527,8 +527,11 @@ class Fetcher:
             return []
         if isinstance(starttime, pd.Series):
             # Have to get clever here to make sure only active stations get used
-            df["starttime"] = starttime.loc[set(starttime.index).intersection(df.index)]
-            df["endtime"] = endtime.loc[set(endtime.index).intersection(df.index)]
+            # and indices are not duplicated.
+            new_start = starttime.loc[set(starttime.index).intersection(df.index)]
+            new_end = endtime.loc[set(endtime.index).intersection(df.index)]
+            df["starttime"] = new_start.loc[~new_start.index.duplicated()]
+            df["endtime"] = endtime.loc[~new_end.index.duplicated()]
         else:
             df["starttime"] = starttime
             df["endtime"] = endtime

--- a/obsplus/structures/fetcher.py
+++ b/obsplus/structures/fetcher.py
@@ -531,7 +531,7 @@ class Fetcher:
             new_start = starttime.loc[set(starttime.index).intersection(df.index)]
             new_end = endtime.loc[set(endtime.index).intersection(df.index)]
             df["starttime"] = new_start.loc[~new_start.index.duplicated()]
-            df["endtime"] = endtime.loc[~new_end.index.duplicated()]
+            df["endtime"] = new_end.loc[~new_end.index.duplicated()]
         else:
             df["starttime"] = starttime
             df["endtime"] = endtime


### PR DESCRIPTION
Fixed an issue with duplicate channels setting incorrect `start_date` on station level.