### PR TITLE
Broaden the default columns for the dataframe extractors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,9 @@ obsplus master
   - obsplus.EventBank
     * Added `overwrite_existing` keyword to `put_events` to disable squashing
       existing events if desired (#191).
+  - obsplus.events.pd
+    * Made sure that the pre-defined extractors (`*_to_df`) still return all of
+      the expected columns if there are no valid objects.
 
 obsplus 0.1.1
   - obsplus.events

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -209,18 +209,7 @@ AMPLITUDE_DTYPES = OrderedDict(
     confidence_level=float,
 )
 
-AMPLITUDE_COLUMNS = (
-    "resource_id",
-    "event_id",
-    "event_time",
-    "generic_amplitude",
-    "type",
-    "magnitude_hint",
-    "network",
-    "station",
-    "location",
-    "channel",
-)
+AMPLITUDE_COLUMNS = tuple(AMPLITUDE_DTYPES)
 
 # columns required for station magnitudes
 STATION_MAGNITUDE_DTYPES = OrderedDict(
@@ -247,15 +236,8 @@ STATION_MAGNITUDE_DTYPES = OrderedDict(
     confidence_level=float,
 )
 
-STATION_MAGNITUDE_COLUMNS = (
-    "resource_id",
-    "mag",
-    "station_magnitude_type",
-    "network",
-    "station",
-    "location",
-    "channel",
-)
+# This is messy, but want to exclude the magnitude_id column
+STATION_MAGNITUDE_COLUMNS = tuple(set(STATION_MAGNITUDE_DTYPES.keys()) - {"magnitude_id"})
 
 # columns required for magnitudes
 MAGNITUDE_DTYPES = OrderedDict(
@@ -280,7 +262,7 @@ MAGNITUDE_DTYPES = OrderedDict(
     confidence_level=float,
 )
 
-MAGNITUDE_COLUMNS = ("resource_id", "event_id", "event_time", "mag", "magnitude_type")
+MAGNITUDE_COLUMNS = tuple(MAGNITUDE_DTYPES)
 
 # columns required for arrivals
 ARRIVAL_DTYPES = OrderedDict(
@@ -310,22 +292,7 @@ ARRIVAL_DTYPES = OrderedDict(
     origin_time="datetime64[ns]",
 )
 
-ARRIVAL_COLUMNS = (
-    "resource_id",
-    "origin_id",
-    "origin_time",
-    "pick_id",
-    "phase",
-    "time_residual",
-    "azimuth",
-    "distance",
-    "time_weight",
-    "time_correction",
-    "network",
-    "station",
-    "location",
-    "channel",
-)
+ARRIVAL_COLUMNS = tuple(ARRIVAL_DTYPES)
 
 # Waveform datatypes
 WAVEFORM_DTYPES = OrderedDict(

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -237,7 +237,9 @@ STATION_MAGNITUDE_DTYPES = OrderedDict(
 )
 
 # This is messy, but want to exclude the magnitude_id column
-STATION_MAGNITUDE_COLUMNS = tuple(set(STATION_MAGNITUDE_DTYPES.keys()) - {"magnitude_id"})
+STATION_MAGNITUDE_COLUMNS = tuple(
+    set(STATION_MAGNITUDE_DTYPES.keys()) - {"magnitude_id"}
+)
 
 # columns required for magnitudes
 MAGNITUDE_DTYPES = OrderedDict(

--- a/tests/test_utils/test_stations_utils.py
+++ b/tests/test_utils/test_stations_utils.py
@@ -205,7 +205,7 @@ class TestDfToInventoryGetResponses:
             df = obsplus.stations_to_df(inv)
 
         # set instrument str
-        sensor_keys = ("Nanometrics", "Trillium 120 Horizon")
+        sensor_keys = ("Nanometrics", "Trillium 120 Horizon", "Trillium 120 Horizon")
         # get digitizer keys
         datalogger_keys = (
             "Nanometrics",


### PR DESCRIPTION
This PR changes the behavior of the pre-defined `DataFrameExtractor`s (`amplitudes_to_df`, `station_magnitudes_to_df`, `magnitudes_to_df`, and `arrivals_to_df`) to include all of the expected columns by default if no matching objects were found.