### PR TITLE
Fix picks_to_df with location code with decimal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,9 @@ obsplus master
   - obsplus.utils
     * Fixed issue with duplicate channels setting incorrect start_dates
       on station level (#188, #190).
+    * Fixed an issue with `picks_to_df` which would return the wrong channel
+      code if the location code had a decimal. Now a ValueError is raised if
+      any seed ids are found which don't have exactly 3 decimals (see #193).
   - obsplus.EventBank
     * Added `overwrite_existing` keyword to `put_events` to disable squashing
       existing events if desired (#191).

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -559,6 +559,10 @@ def _get_uncertainty(errors):
 def _get_seed_id(obj):
     """ Strip nslc info for an extractor """
     seed_id = get_seed_id(obj)
+    split = seed_id.split(".")
+    if len(split) != 4:
+        msg = f"The seed_id: {seed_id} is not valid. It was found on {obj}"
+        raise ValueError(msg)
     dd = {x: y for x, y in zip(NSLC, seed_id.split("."))}
     return {"seed_id": seed_id, **dd}
 

--- a/obsplus/utils/events.py
+++ b/obsplus/utils/events.py
@@ -363,7 +363,7 @@ def get_seed_id(obj: catalog_component) -> str:
     # go down a level until it finds a seed id
     for att in attrs:
         val = getattr(obj, att, None)
-        if val:
+        if val is not None:
             with suppress((TypeError, AttributeError)):
                 return get_seed_id(val)
     # If it makes it this far, it could not find a non-None attribute

--- a/tests/test_events/test_pd_events.py
+++ b/tests/test_events/test_pd_events.py
@@ -642,6 +642,18 @@ class TestReadPicks:
         assert len(set(df["location"])) == 2
         assert len(set(df["seed_id"])) == 2
 
+    def test_dot_in_location_code(self):
+        """Ensure a dot in the location code causes a ValueError. """
+        waveform_id = ev.WaveformStreamID(
+            network_code="UU",
+            station_code="TMU",
+            location_code="1.0",
+            channel_code="HHZ",
+        )
+        pick = ev.Pick(time=obspy.UTCDateTime("2020-01-01"), waveform_id=waveform_id)
+        with pytest.raises(ValueError):
+            _ = obsplus.picks_to_df([pick])
+
     def test_gather(self, catalog_output, dataframe_output):
         """ Simply gather aggregated fixtures so they are marked as used. """
 


### PR DESCRIPTION
Previously a location code with a decimal would result in the incorrect channel code. For example, a pick with a seed id of:
'UU.TMU.0.1.HHZ` would result in a channel code of '1'. 

This PR now raises a `ValueError` if splitting a seed id results in a list which is not exactly 4 elements long.

While fixing this issues I found the `NRL` response added an additional instrument to the trillium 120 series which required changing the `sensor_keys` slightly to get the same response which was previously returned.



