### PR TITLE
Dynamically created dataset

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ obsplus master
   - obsplus.EventBank
     * Added `overwrite_existing` keyword to `put_events` to disable squashing
       existing events if desired (#191).
+    * Fixes issue with read inventory casting ints to datetime on pd 1.1.0
   - obsplus.events.pd
     * Made sure that the pre-defined extractors (`*_to_df`) still return all of
       the expected columns if there are no valid objects.

--- a/obsplus/utils/pd.py
+++ b/obsplus/utils/pd.py
@@ -122,14 +122,15 @@ def _ints_to_time_columns(df, columns=None, nat_value=SMALLDT64):
 
     Needs a fill value for NaT.
     """
+    # TODO will have to be more specific if we ever add other int cols
     dtypes = [int, np.int64]
     cols = columns or df.select_dtypes(include=dtypes).columns
-    df.loc[:, cols] = (
+    ser = (
         df.loc[:, cols]
         .apply(pd.to_datetime, unit="ns", axis=1)
         .replace(nat_value, np.datetime64("NaT"))
     )
-    return df
+    return pd.concat([df.drop(columns=cols), ser], axis=1)[df.columns]
 
 
 def cast_dtypes(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -524,11 +524,20 @@ class TestBasicDataset:
         assert isinstance(client, WaveformClient)
         ds._download_client = client
 
-    def test_source_path_of_dynamic_dataset(self):
-        """Ensure a sensible default source_path is created """
+    def test_dynamic_dataset_no_source_path(self):
+        """Ensure a source path isn't required.
+        (no reason to create an empty directory)
+        """
         kwargs = dict(name="bob", version="0.1.0")
+        # first make sure the expected source path doesn't exist
         ds = type("test_dataset", (DataSet,), kwargs)()
-        assert ds.source_path.exists()
+        if ds.source_path.exists():
+            shutil.rmtree(str(ds.source_path))
+        # then ensure it isn't created
+        ds = type("test_dataset", (DataSet,), kwargs)()
+        assert not ds.source_path.exists()
+        # but that the *data path* was
+        assert ds.data_path.exists()
 
     def test_load_failure_warns(self, tmp_path):
         """Ensure when a load functions raises it issues a warning. """


### PR DESCRIPTION
@sboltz found a weird edge case where `Dataset`s created with `type` would put their source directory in the standard library folders. This is less than ideal, and it turns out the source paths aren't automatically created anyway. I modified the failing test to test that an empty source directory is not created (why create an empty directory that will never be populated anyway?).

This is an extreme edge case. I don't anticipate it will effect any users. 