### PR TITLE
SpatialCalculator DataFrame input columns

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@ obsplus master
     * Fixed an issue with `picks_to_df` which would return the wrong channel
       code if the location code had a decimal. Now a ValueError is raised if
       any seed ids are found which don't have exactly 3 decimals (see #193).
+    * Made sure that `SpatialCalculator` returns a meaningful error message if
+      required columns are missing from DataFrame inputs (#197).
   - obsplus.EventBank
     * Added `overwrite_existing` keyword to `put_events` to disable squashing
       existing events if desired (#191).

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -171,6 +171,10 @@ DISTANCE_COLUMN_INPUT_DTYPES = OrderedDict(
     latitude=float, longitude=float, elevation=float
 )
 
+ALT_DISTANCE_COLUMN_DTYPES = OrderedDict(
+    latitude=float, longitude=float, depth=float
+)
+
 # DISTANCE_COLUMNS = tuple(DISTANCE_COLUMN_DTYPES)
 # DISTANCE_INPUT_COLUMNS = tuple(DISTANCE_COLUMN_INPUT_DTYPES)
 

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -171,9 +171,7 @@ DISTANCE_COLUMN_INPUT_DTYPES = OrderedDict(
     latitude=float, longitude=float, elevation=float
 )
 
-ALT_DISTANCE_COLUMN_DTYPES = OrderedDict(
-    latitude=float, longitude=float, depth=float
-)
+ALT_DISTANCE_COLUMN_DTYPES = OrderedDict(latitude=float, longitude=float, depth=float)
 
 # DISTANCE_COLUMNS = tuple(DISTANCE_COLUMN_DTYPES)
 # DISTANCE_INPUT_COLUMNS = tuple(DISTANCE_COLUMN_INPUT_DTYPES)

--- a/obsplus/utils/geodetics.py
+++ b/obsplus/utils/geodetics.py
@@ -135,9 +135,8 @@ class SpatialCalculator:
         # first cull out columns that aren't needed and de-dup index
         if ("depth" in df.columns) and ("elevation" not in df.columns):
             # Make sure that the df has an elevation column
-            out = (
-                df[list(ALT_DISTANCE_COLUMN_DTYPES)]
-                .astype(ALT_DISTANCE_COLUMN_DTYPES)
+            out = df[list(ALT_DISTANCE_COLUMN_DTYPES)].astype(
+                ALT_DISTANCE_COLUMN_DTYPES
             )
             out["elevation"] = -1 * out["depth"]
             out.drop("depth", inplace=True, axis=1)

--- a/obsplus/utils/geodetics.py
+++ b/obsplus/utils/geodetics.py
@@ -73,7 +73,8 @@ class SpatialCalculator:
                 set(cols).issubset(obj.columns) or set(cols1).issubset(obj.columns)
             ):
                 raise DataFrameContentError(
-                    f"SpatialCalculator input dataframe must have the following columns: {cols} or {cols1}"
+                    "SpatialCalculator input dataframe must have the following "
+                    f"columns: {cols} or {cols1}"
                 )
             return self._validate_dataframe(obj)
         try:  # first try events
@@ -132,7 +133,7 @@ class SpatialCalculator:
     def _validate_dataframe(self, df) -> pd.DataFrame:
         """ Ensure all the parameters of the dataframe are reasonable. """
         # first cull out columns that aren't needed and de-dup index
-        if ("depth" in df.columns) and (not "elevation" in df.columns):
+        if ("depth" in df.columns) and ("elevation" not in df.columns):
             # Make sure that the df has an elevation column
             out = (
                 df[list(ALT_DISTANCE_COLUMN_DTYPES)]

--- a/obsplus/utils/geodetics.py
+++ b/obsplus/utils/geodetics.py
@@ -138,9 +138,10 @@ class SpatialCalculator:
             out = (
                 df[list(ALT_DISTANCE_COLUMN_DTYPES)]
                 .astype(ALT_DISTANCE_COLUMN_DTYPES)
-                .pipe(self._de_duplicate_df_index)
             )
             out["elevation"] = -1 * out["depth"]
+            out.drop("depth", inplace=True, axis=1)
+            self._de_duplicate_df_index(out)
         else:
             out = (
                 df[list(DISTANCE_COLUMN_INPUT_DTYPES)]
@@ -150,9 +151,8 @@ class SpatialCalculator:
         # sanity checks on lat/lon
         lat_valid = abs(df["latitude"]) <= 90.0
         lons_valid = abs(df["longitude"]) <= 180.0
-        elevs_valid = df["elevation"].notnull()
-        if not (lat_valid.all() & lons_valid.all() & elevs_valid.all()):
-            msg = f"invalid lat/lon/elevation values found in {df}"
+        if not (lat_valid.all() & lons_valid.all()):
+            msg = f"invalid lat/lon values found in {df}"
             raise DataFrameContentError(msg)
         return out
 

--- a/obsplus/utils/geodetics.py
+++ b/obsplus/utils/geodetics.py
@@ -69,7 +69,9 @@ class SpatialCalculator:
         cols1 = list(ALT_DISTANCE_COLUMN_DTYPES)
         # if a dataframe is used
         if isinstance(obj, pd.DataFrame):
-            if not (set(cols).issubset(obj.columns) or set(cols1).issubset(obj.columns)):
+            if not (
+                set(cols).issubset(obj.columns) or set(cols1).issubset(obj.columns)
+            ):
                 raise DataFrameContentError(
                     f"SpatialCalculator input dataframe must have the following columns: {cols} or {cols1}"
                 )

--- a/tests/test_utils/test_geodetics.py
+++ b/tests/test_utils/test_geodetics.py
@@ -153,6 +153,7 @@ class TestCalculateDistance:
             spatial_calc(cat, df2)
 
     def test_invalid_lat_lon(self, spatial_calc, cat, inv):
+        """ Ensure invalid latitudes or longitudes get flagged """
         df = inv.to_df()
         df["latitude"] = 200
         with pytest.raises(DataFrameContentError, match="invalid lat/lon"):

--- a/tests/test_utils/test_geodetics.py
+++ b/tests/test_utils/test_geodetics.py
@@ -141,7 +141,13 @@ class TestCalculateDistance:
         """ Ensure dfs with missing columns raise. """
         df1 = cat.to_df().drop(columns="latitude")
         df2 = inv.to_df().drop(columns="latitude")
-        with pytest.raises(DataFrameContentError, match="SpatialCalculator input dataframe must have the following"):
+        with pytest.raises(
+            DataFrameContentError,
+            match="SpatialCalculator input dataframe must have the following",
+        ):
             spatial_calc(df1, inv)
-        with pytest.raises(DataFrameContentError, match="SpatialCalculator input dataframe must have the following"):
+        with pytest.raises(
+            DataFrameContentError,
+            match="SpatialCalculator input dataframe must have the following",
+        ):
             spatial_calc(cat, df2)

--- a/tests/test_utils/test_geodetics.py
+++ b/tests/test_utils/test_geodetics.py
@@ -151,3 +151,9 @@ class TestCalculateDistance:
             match="SpatialCalculator input dataframe must have the following",
         ):
             spatial_calc(cat, df2)
+
+    def test_invalid_lat_lon(self, spatial_calc, cat, inv):
+        df = inv.to_df()
+        df["latitude"] = 200
+        with pytest.raises(DataFrameContentError, match="invalid lat/lon"):
+            spatial_calc(cat, df)

--- a/tests/test_utils/test_geodetics.py
+++ b/tests/test_utils/test_geodetics.py
@@ -137,9 +137,11 @@ class TestCalculateDistance:
             spatial_calc(cat, (45, -111, 0))
         assert "multiple coordinates for" in e.value.args[0]
 
-    def test_invalid_df(self, spatial_calc):
+    def test_invalid_df(self, spatial_calc, cat, inv):
         """ Ensure dfs with missing columns raise. """
-        df = obsplus.events_to_df(obspy.read_events())
-        df2 = df.drop(columns="latitude")
-        with pytest.raises(DataFrameContentError):
-            spatial_calc(df, df2)
+        df1 = cat.to_df().drop(columns="latitude")
+        df2 = inv.to_df().drop(columns="latitude")
+        with pytest.raises(DataFrameContentError, match="SpatialCalculator input dataframe must have the following"):
+            spatial_calc(df1, inv)
+        with pytest.raises(DataFrameContentError, match="SpatialCalculator input dataframe must have the following"):
+            spatial_calc(cat, df2)


### PR DESCRIPTION
This PR addresses a subtle issue where if an input DataFrame was missing expected columns (or, in my case, they were named something other than what was expected) it would get passed down to the next parser in the chain, which was the `events_to_df` extractor. As a result the `events_to_df` extractor would simply return the dataframe with the "missing" columns added and filled with NaNs. This would later raise upon validating the df, but the error was much more obscure than if it were just caught earlier.

The fix to this was a little bit more involved than I expected because it also had to account for the fact that an events DataFrame is most likely going to have the column "depth" rather than "elevation". As a result, I am open to suggestions on cleaning it up a bit.