### PR TITLE
EventBank.get_events to ignore deleted files

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: 3.7
 
       - name: install linting packages
-        run: pip install -r tests/requirements.txt
+        run: pip install pre-commit
 
       - name: run all precommits
         run: pre-commit run flake8 --files obsplus/**/*

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,7 +13,9 @@ obsplus master
   - obsplus.EventBank
     * Added `overwrite_existing` keyword to `put_events` to disable squashing
       existing events if desired (#191).
-    * Fixes issue with read inventory casting ints to datetime on pd 1.1.0
+    * Fixes issue with read inventory casting ints to datetime on pd 1.1.0.
+    * Fixed issue which caused reading deleted files from an EventBank to
+      raise a TypeError (#198).
   - obsplus.events.pd
     * Made sure that the pre-defined extractors (`*_to_df`) still return all of
       the expected columns if there are no valid objects.

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -400,11 +400,13 @@ class EventBank(_Bank):
         map_kwargs = dict(chunksize=chunksize)
         try:
             mapped_values = self._map(read_func, paths.values, **map_kwargs)
-            cat = reduce(add, mapped_values)
+            non_none_values = (x for x in mapped_values if x is not None)
+            cat = reduce(add, non_none_values)
         except TypeError:  # empty events
             cat = obspy.Catalog()
         # Make sure only the events of interest are included
-        return obspy.Catalog([eve for eve in cat if eve.resource_id.id in eids.values])
+        events = [eve for eve in cat if eve.resource_id.id in eids.values]
+        return obspy.Catalog(events=events)
 
     def ids_in_bank(self, event_id: Union[str, Sequence[str]]) -> Set[str]:
         """

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -6,7 +6,7 @@ import time
 from concurrent.futures import Executor
 from functools import reduce, partial
 from operator import add
-from os.path import exists, getmtime
+from os.path import getmtime
 from pathlib import Path
 from typing import Optional, Union, Sequence, Set
 
@@ -506,7 +506,6 @@ class EventBank(_Bank):
         if rid in df.index:  # event needs to be updated
             path = df.loc[rid, "path"]
             save_path = bank_path + path
-            assert exists(save_path)
             if not overwrite_existing:  # dont update existing
                 return
         else:  # event file does not yet exist

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -124,7 +124,7 @@ def check_duplicate_picks(event: Event):
 
 
 @validator("obsplus", Event)
-def check_pick_order(event: Event,):
+def check_pick_order(event: Event):
     """
     Ensure:
         1. There are no S picks before P picks on any station

--- a/obsplus/utils/misc.py
+++ b/obsplus/utils/misc.py
@@ -17,7 +17,6 @@ from typing import (
     Optional,
     Callable,
     Union,
-    Sequence,
     TypeVar,
     Collection,
     Dict,
@@ -288,7 +287,7 @@ def iterate(obj):
         return ()
     if isinstance(obj, str):
         return (obj,)
-    return obj if isinstance(obj, Sequence) else (obj,)
+    return obj if isinstance(obj, Iterable) else (obj,)
 
 
 class DummyFile(object):

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -720,7 +720,7 @@ class TestBankCache:
     # fixtures
     @pytest.fixture(scope="class")
     def mp_ta_bank(self, ta_bank):
-        """ monkey patch the ta_bank instance to count how many times the .h5
+        """monkey patch the ta_bank instance to count how many times the .h5
         index is accessed, store it on the accessed_times in the ._cache.times
         """
         func = count_calls(ta_bank, ta_bank._index_cache._get_index, "index_calls")
@@ -1352,7 +1352,7 @@ class TestConcurrentUpdateIndex:
 
 
 class TestSelectDoesntReturnSuperset:
-    """ make sure selecting on an attribute doesnt return a superset of that
+    """make sure selecting on an attribute doesnt return a superset of that
     attribute. EG, selecting station '2' should not also return station '22'
     """
 

--- a/tests/test_events/test_pd_events.py
+++ b/tests/test_events/test_pd_events.py
@@ -738,7 +738,7 @@ class TestReadArrivals:
         assert floatify_dict(ser_dict) == floatify_dict(arr_dict)
 
     # empty catalog tests
-    def test_empty_catalog(self,):
+    def test_empty_catalog(self):
         """ ensure returns empty df with required columns """
         empty_cat = ev.Catalog()
         df = arrivals_to_dataframe(empty_cat)
@@ -868,7 +868,7 @@ class TestReadAmplitudes:
         assert amp_series["author"] == amplitude.creation_info.author
         assert amp_series["agency_id"] == amplitude.creation_info.agency_id
 
-    def test_empty_catalog(self,):
+    def test_empty_catalog(self):
         """ ensure returns empty df with required columns """
         df = amplitudes_to_dataframe(ev.Catalog())
         assert isinstance(df, pd.DataFrame)
@@ -987,7 +987,7 @@ class TestReadStationMagnitudes:
         assert sm.magnitude_id == dummy_mag.resource_id.id
 
     # empty catalog tests
-    def test_empty_catalog(self,):
+    def test_empty_catalog(self):
         """ ensure returns empty df with required columns """
         empty_cat = ev.Catalog()
         df = station_magnitudes_to_dataframe(empty_cat)

--- a/tests/test_utils/test_event_utils.py
+++ b/tests/test_utils/test_event_utils.py
@@ -79,7 +79,7 @@ class TestDuplicateEvent:
         obsplus.validate_catalog(duplicated_big_catalog)
 
     def test_interconnected_rids(self, catalog_cache):
-        """ Tests for ensuring resource IDs are changed to point to new
+        """Tests for ensuring resource IDs are changed to point to new
         objects. This can get messed up when there are many objects
         that point to resource ids of other objects. EG picks/amplitudes.
         """

--- a/tests/test_utils/test_misc_utils.py
+++ b/tests/test_utils/test_misc_utils.py
@@ -46,7 +46,7 @@ class TestReplaceNullSeedCodes:
     """ tests for replacing nulish NSLC codes for various objects. """
 
     @pytest.fixture
-    def null_stream(self,):
+    def null_stream(self):
         """ return a stream with various nullish nslc codes. """
         st = obspy.read()
         st[0].stats.location = ""
@@ -268,7 +268,7 @@ class TestProgressBar:
         monkeypatch.setattr(ProgressBar, "start", raise_exception)
         assert obsplus.utils.misc.get_progressbar(100) is None
 
-    def test_simple_progress_bar(self,):
+    def test_simple_progress_bar(self):
         """ Ensure a simple progress bar can be used. """
         ProgressBar = obsplus.utils.misc._get_progressbar()
 

--- a/wip/bigcatalog/test_bigcatalog.py
+++ b/wip/bigcatalog/test_bigcatalog.py
@@ -26,9 +26,9 @@ class TestCatalogInterface:
     """ The big events should look and feel like a normal events. """
 
     def prune_catalog(self, catalog):
-        """ recurse a events and set all attrs that eval to False to None.
+        """recurse a events and set all attrs that eval to False to None.
         This is needed to overcome some Catalog oddities to fairly compare two
-        catalogs. """
+        catalogs."""
         skips = (obspy.UTCDateTime, ev.ResourceIdentifier)
         cat = catalog.copy()
         for obj, parent, attr in yield_obj_parent_attr(cat):

--- a/wip/chainclient/test_chainclient.py
+++ b/wip/chainclient/test_chainclient.py
@@ -65,8 +65,8 @@ class TestChainClientBasic:
         assert isinstance(bing_stream, obspy.Stream)
 
     def test_backup_stream(self, backup_stream):
-        """ ask for data only found in clients attr to make when it is not
-        found in other clients the backup is used """
+        """ask for data only found in clients attr to make when it is not
+        found in other clients the backup is used"""
         assert len(backup_stream)
         assert isinstance(backup_stream, obspy.Stream)
 

--- a/wip/wavecache/test_wavecache.py
+++ b/wip/wavecache/test_wavecache.py
@@ -42,8 +42,8 @@ class TestBasics:
         assert st2 is st
 
     def test_add_processor(self, wavecache):
-        """ ensure when a processor is added it runs on the streams, and all
-        processors can be cleared. """
+        """ensure when a processor is added it runs on the streams, and all
+        processors can be cleared."""
         inds = [{}, {}]
         index = 0
 
@@ -82,8 +82,8 @@ class TestBasics:
             assert not hasattr(tr, "new_attr")
 
     def test_waveforms_are_sliced(self, wavecache):
-        """ ensure if the starttime/endtime are specified the waveforms are
-        trimmed to desired time. """
+        """ensure if the starttime/endtime are specified the waveforms are
+        trimmed to desired time."""
         # get time of first trace, set trim times to one second in
         st = wavecache.get_waveforms()
         stats = st[0].stats

--- a/wip/xarray/convert.py
+++ b/wip/xarray/convert.py
@@ -60,7 +60,7 @@ def obspy_to_array_dict(
 
 
 def _iter_events_assemble(waveform: Dict[Any, Union[Stream, Trace]]):
-    """ given a dict of the form {event_id: waveforms}, create a new dict of
+    """given a dict of the form {event_id: waveforms}, create a new dict of
     the structure {sampling_rage: {event_id: waveforms}}"""
     out = defaultdict(lambda: defaultdict(obspy.Stream))
     for item, value in waveform.items():
@@ -75,8 +75,8 @@ def _iter_events_assemble(waveform: Dict[Any, Union[Stream, Trace]]):
 def _split_by_sampling_rate(
     st: Union[obspy.Stream, obspy.Trace]
 ) -> Dict[int, obspy.Stream]:
-    """ given a waveforms, split the waveforms into dicts with unique sampling
-    rates """
+    """given a waveforms, split the waveforms into dicts with unique sampling
+    rates"""
     if isinstance(st, obspy.Trace):  # convert to waveforms if trace passed
         st = obspy.Stream(traces=[st])
     # iterate and separate sampling_rates
@@ -231,8 +231,8 @@ def _trace_to_datarray(trace: obspy.Trace) -> xr.DataArray:
 
 
 def _get_starttime_df(waveform):
-    """ return a df of starttimes with stream_id as coulmns and seed_id as
-    index """
+    """return a df of starttimes with stream_id as coulmns and seed_id as
+    index"""
     start_time = {
         (stream_id, tr.id): tr.stats.starttime.timestamp
         for stream_id, st in waveform.items()

--- a/wip/xarray/signal.py
+++ b/wip/xarray/signal.py
@@ -8,7 +8,7 @@ from obsplus.waveforms.xarray.utils import keep_attrs
 
 
 def _get_frequencies(dar, dim, dim_len=None):
-    """ get a list of frequencies each complex point represents, return in
+    """get a list of frequencies each complex point represents, return in
     dict for coords input"""
     dim_len = dim_len or len(dar[dim])  # the req_len of the dimension
     try:  # if metadata are still attached (they come off easy)

--- a/wip/xarray/test_xarray_stream.py
+++ b/wip/xarray/test_xarray_stream.py
@@ -30,8 +30,8 @@ rand = np.random.RandomState(13)
 
 
 def starttimes_consistent(dar, tolerance=0.0001):
-    """ Return True if the starttimes in the data array are consistent with
-    those in the attrs """
+    """Return True if the starttimes in the data array are consistent with
+    those in the attrs"""
 
     for eve_id, stat_dict in dar.attrs["stats"].items():
         for chan_id, stats in stat_dict.items():
@@ -82,7 +82,7 @@ class TestWaveform2ArrayDict:
 
     @pytest.fixture(scope="class")
     def array_dict_different_sr(self):
-        """ return a data_array dict made from a waveforms with different sample
+        """return a data_array dict made from a waveforms with different sample
         rates"""
         st = obspy.read()
         out = {}
@@ -117,8 +117,8 @@ class TestWaveform2ArrayDict:
 
     # homogeneous tests
     def test_default_array_is_len_1(self, homogeneous_array_dict):
-        """ since the default array only has 1 sampling rate it should produce
-        a dict with only one key """
+        """since the default array only has 1 sampling rate it should produce
+        a dict with only one key"""
         assert isinstance(homogeneous_array_dict, dict)
         assert len(homogeneous_array_dict) == 1
         # ensure each element is a data array
@@ -180,8 +180,8 @@ class TestStreamDict2DataArray:
         assert "starttime" in dar.coords
 
     def test_bingham_data_array(self, bingham_dar, bingham_stream_dict):
-        """ ensure the bingham_test data array does not contain NaNs and has
-        correct starttimes """
+        """ensure the bingham_test data array does not contain NaNs and has
+        correct starttimes"""
         assert not bingham_dar.isnull().any()
         assert set(bingham_dar.stream_id.values) == set(bingham_stream_dict)
         assert starttimes_consistent(bingham_dar, tolerance=0.02)
@@ -195,8 +195,8 @@ class TestStreamDict2DataArray:
                 assert abs(time - ar_time) < 1
 
     def test_disjoint_seed_ids(self, dar_disjoint_seeds):
-        """ test that data arrays with disjoint seed ids still return some
-        values """
+        """test that data arrays with disjoint seed ids still return some
+        values"""
         dar = dar_disjoint_seeds
         assert len(dar.time.values), " empty time dimension "
 
@@ -370,8 +370,8 @@ class TestArray2Dict:
         return st
 
     def equal_without_processing(self, st1, st2):
-        """ Return True if the streams are equal when processing in stats is
-        removed """
+        """Return True if the streams are equal when processing in stats is
+        removed"""
         st1, st2 = self._remove_processing(st1), self._remove_processing(st2)
         # make sure lengths are the same
         for tr1, tr2 in zip(st1, st2):
@@ -497,8 +497,8 @@ class TestAttachPicks:
             assert not dtype.hasobject  # shouldn't be an object dtype
 
     def test_starttime_origin_time_seperation(self, dar_attached_picks):
-        """ ensure the start of the trace and start of the events arent too
-        far off """
+        """ensure the start of the trace and start of the events arent too
+        far off"""
         dar = dar_attached_picks
         cat = dar.attrs["events"]
         for ev in cat:
@@ -539,8 +539,8 @@ class TestTrimArray:
     # fixtures
     @pytest.fixture(scope="class")
     def trimmed_dar(self, dar_attached_picks):
-        """ copy the data array with attached picks and trim the channels
-        independently """
+        """copy the data array with attached picks and trim the channels
+        independently"""
         dar = copy.deepcopy(dar_attached_picks)
         return dar.ops.trim(trim="p_time")
 
@@ -622,7 +622,7 @@ class TestTrimArray:
         assert hasattr(trimmed_dar, "attrs")
 
     def test_all_times_changed(self, trimmed_group, attached_picks_and_groups):
-        """ since each waveform was in a group that had a change, all of the
+        """since each waveform was in a group that had a change, all of the
         start times should now be different
         """
         dar1, dar2 = trimmed_group, attached_picks_and_groups
@@ -734,8 +734,7 @@ class TestPadTime:
         assert t1[-1] > t2[-1]
 
     def test_trimmed_array(self, default_array):
-        """ ensure the array was trimmed when a negative time_before is used
-        """
+        """ensure the array was trimmed when a negative time_before is used"""
         negative_pad_time = pad_time(default_array, time_before=self.negative_time)
 
         old_time = default_array.time.values
@@ -792,8 +791,8 @@ class TestAggregations:
 
     # helper functions
     def split_seeds(self, dar):
-        """ split the seed_ids, return a df with columns: network, station,
-        location, channel, if all are present, else return a subset """
+        """split the seed_ids, return a df with columns: network, station,
+        location, channel, if all are present, else return a subset"""
         ser = dar.seed_id.to_dataframe()["seed_id"]
         split = ser.str.split(".", expand=True)
         # reset columns to seed_col names
@@ -817,8 +816,8 @@ class TestAggregations:
 
     @pytest.fixture(params=common_fixtures)
     def aggregated(self, request):
-        """ parametrize all aggregation fixtures to run through basic common
-        tests """
+        """parametrize all aggregation fixtures to run through basic common
+        tests"""
         return request.getfixturevalue(request.param)
 
     @pytest.fixture
@@ -872,16 +871,16 @@ class TestAggregations:
         assert zoo_std_all.to_dataset(name="var").dims["seed_id"] == 1
 
     def test_groups_are_truncated_1d(self, aggregated_with_group_1d):
-        """ ensure the group coord is truncated to reflect the station
-        aggregation """
+        """ensure the group coord is truncated to reflect the station
+        aggregation"""
         ar = aggregated_with_group_1d
         groups = ar.coords["group"]
         for group in groups.values.flatten():
             assert len(str(group).split(".")) == 2  # only station level
 
     def test_groups_are_truncated_2d(self, aggregated_with_group_2d):
-        """ ensure the group coord is truncated to reflect the station
-        aggregation """
+        """ensure the group coord is truncated to reflect the station
+        aggregation"""
         ar = aggregated_with_group_2d
         groups = ar.coords["group"]
         for group in groups.values.flatten():
@@ -1010,8 +1009,8 @@ class TestArrayFFTAndIFFT:
         assert array_fft_outputs.values.dtype == np.complex128
 
     def test_requencies(self, array_fft_outputs):
-        """ ensure frequency is an axis and has both positive and negative
-         numbers """
+        """ensure frequency is an axis and has both positive and negative
+        numbers"""
         assert "frequency" in array_fft_outputs.coords
         freqs = array_fft_outputs.coords["frequency"].values
         assert freqs[0] == 0
@@ -1151,8 +1150,8 @@ class Test2Netcdf:
     # fixtures
     @pytest.fixture(scope="class")
     def default_array_more(self, default_array: xr.DataArray):
-        """ return a deep copy of the default array with
-        an obspy events and stations attached """
+        """return a deep copy of the default array with
+        an obspy events and stations attached"""
         dar = default_array.copy(deep=True)
         dar.attrs["events"] = obspy.read_events()
         dar.attrs["stations"] = obspy.read_inventory()

--- a/wip/xarray/utils.py
+++ b/wip/xarray/utils.py
@@ -106,8 +106,8 @@ def trim_waveform_array(
 
 
 def _prepare_trim_output(dar, out, remove_nan):
-    """ prepare the output of trim function by adjusting starttimes, deleting
-    temporary coord, and removing nan output """
+    """prepare the output of trim function by adjusting starttimes, deleting
+    temporary coord, and removing nan output"""
     # TODO remove this when xarray issue # 1428 gets resolved
     if (dar.starttime == out.starttime).all():  # starttimes didnt update
         fill_values = out.coords["_trim"].fillna(0.0)
@@ -130,7 +130,7 @@ def _overwrite_group_values(dar: xr.DataArray, func: Callable):
 
 
 def _get_trim_data_array(dar, trim, is_timestamp):
-    """ return a data array that shares some dims with dar for trimming.
+    """return a data array that shares some dims with dar for trimming.
     Values in data array will be referenced from the start of each waveform
     rather than a timestamp"""
     # figure out what trim is turn it into a data array
@@ -160,7 +160,7 @@ def _trim_array(dar: xr.DataArray):  # , trim_coord: str,
 
 
 def get_seed_id_df(dar: xr.DataArray) -> pd.DataFrame:
-    """ return a dataframe with network station location channel
+    """return a dataframe with network station location channel
     from seed_id on a detex data array"""
     ser = dar.seed_id.to_pandas() if isinstance(dar, xr.DataArray) else dar
     ser_ind = pd.Series(np.array(ser.index), index=ser.index)
@@ -415,8 +415,8 @@ def reset_time(dar: xr.DataArray, inplace=False) -> xr.DataArray:
 
 
 def _add_level(dar, level, dim="seed_id", coord=None):
-    """ given a data array, add the level the aggregation is to occur on
-     to the coord """
+    """given a data array, add the level the aggregation is to occur on
+    to the coord"""
     new_coord = None
     assert level in AGG_LEVEL_MAP
     if level == "all":  # set all the seed_ids to 1
@@ -431,8 +431,8 @@ def _add_level(dar, level, dim="seed_id", coord=None):
 
 
 def _adjust_coord(dar, coord, coord_map, level, dim):
-    """ create new dataframe that will be joined back to aggregated data
-    array """
+    """create new dataframe that will be joined back to aggregated data
+    array"""
     # TODO this is ugly and probably not efficient, clean up
     assert coord in dar.coords, f"{coord} is not found in coord of {dar}"
     # convert to dataframe and replace any full seed str with substr


### PR DESCRIPTION
If a file is deleted from an `EventBank`'s directory, then requested in a `get_events` call a `TypeError` is currently raised. This PR changes the behavior so that a `UserWarning` is issued and an empty catalog is returned. 