### PR TITLE
Merge new picks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,9 +24,13 @@ obsplus master
   - obsplus.events.pd
     * Made sure that the pre-defined extractors (`*_to_df`) still return all of
       the expected columns if there are no valid objects.
-  - obsplus.stations.pd.inventory_to_df
+  - obsplus.stations
     * Made sure that location codes and other NSLC components are handled
-      consistently (#199)
+      consistently within stations_to_df (#199).
+  - obsplus.events.merge
+    # Added a new function called associate merge for merging one event with
+      the closest (defined by median pick time) of several possible events
+      (#200).
 
 obsplus 0.1.1
   - obsplus.events

--- a/tests/test_events/test_merge.py
+++ b/tests/test_events/test_merge.py
@@ -292,3 +292,11 @@ class TestAttachNewOrigin:
         self.origin_is_preferred(cat1, origin)
         assert origin in cat1[0].origins
         assert cat1[0].origins[-1] == origin
+
+
+class TestMergeNewPicks:
+    """Tests for merging new picks into old catalogs."""
+
+    @pytest.fixture
+    def catalog_to_merge(self, bingham_cat):
+        """Create a catalog to merge into bingham_cat."""


### PR DESCRIPTION
This PR adds a function to `obsplus.events.merge` called `associate_merge` which merges a known event with one of several possible events on a median pick time. It is rather naive but should be good enough for most cases.

I needed this function for merging picks made by an automatic picker back into an event when the automatic picker can return multiple events. 