### PR TITLE
add update_index argument

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,8 @@ obsplus master
     * Fixes issue with read inventory casting ints to datetime on pd 1.1.0.
     * Fixed issue which caused reading deleted files from an EventBank to
       raise a TypeError (#198).
+    * Added an obscure attribute called 'allow_update_index' for the rare
+      cases when index timestamp shouldn't be updated (#201).
   - obsplus.events.pd
     * Made sure that the pre-defined extractors (`*_to_df`) still return all of
       the expected columns if there are no valid objects.

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -666,6 +666,18 @@ class TestPutEvents:
         mtimes_2 = [x.stat().st_mtime for x in files]
         assert mtimes_1 == mtimes_2
 
+    def test_put_events_no_update_index_timestamp(self, ebank):
+        """
+        Ensure events can be put into the bank without updating the index
+        timestamp.
+        """
+        last_update = ebank.last_updated
+        cat = obspy.read_events()
+        ebank.put_events(cat, update_timestamp=False)
+        time.sleep(0.001)
+        new_update_time = ebank.last_updated
+        assert last_update == new_update_time
+
 
 class TestProgressBar:
     """ Tests for the progress bar functionality of banks. """

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -666,16 +666,18 @@ class TestPutEvents:
         mtimes_2 = [x.stat().st_mtime for x in files]
         assert mtimes_1 == mtimes_2
 
-    def test_put_events_no_update_index_timestamp(self, ebank):
+    def test_put_events_no_update_index_timestamp(self, ebank, monkeypatch):
         """
         Ensure events can be put into the bank without updating the index
         timestamp.
         """
+        monkeypatch.setattr(ebank, "allow_update_timestamp", False)
         last_update = ebank.last_updated
         cat = obspy.read_events()
-        ebank.put_events(cat, update_timestamp=False)
+        ebank.put_events(cat)
         time.sleep(0.001)
         new_update_time = ebank.last_updated
+        # The last updated timestamp should not have changed.
         assert last_update == new_update_time
 
 


### PR DESCRIPTION
This PR adds an attribute called "allow_update_timestamp" to both `EventBank`. It allows for more fine-grained control over when the timestamp contained in the event bank index gets updated. 

Normally this parameter should be left as the default value. However, if there are multiple processes creating files in the `EventBank`'s directory and an event needs to be included in the index immediately it may be appropriate to overwrite the default value. 

I chose to make this an attribute rather than a  function key word argument to avoid further cluttering the API for an obscure feature most people wont need. 