### PR TITLE
Bank raise on unsupported kwargs

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,5 +6,3 @@ labels: question
 assignees: ''
 
 ---
-
-

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -325,10 +325,6 @@ class WaveBank(_Bank):
             kwargs are passed to pandas.read_hdf function
         """
         self.ensure_bank_path_exists()
-        if starttime is not None and endtime is not None:
-            if starttime > endtime:
-                msg = "starttime cannot be greater than endtime."
-                raise ValueError(msg)
         if not self.index_path.exists():
             self.update_index()
         # if no file was created (dealing with empty bank) return empty index

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -350,7 +350,18 @@ EMPTYTD64 = np.timedelta64(0, "s")
 OPSDATA_PATH = Path().home() / "opsdata"
 
 # Number of cores
-CPU_COUNT = cpu_count() or 4  # fallback to four is None is returned
+CPU_COUNT = cpu_count() or 4  # fallback to four if None is returned
+
+# supported read_hdf5 kwargs
+READ_HDF5_KWARGS = frozenset(
+    {"columns", "where", "mode", "errors", "start", "stop", "key", "chunksize"}
+)
+
+# keywords associated with get_events
+CIRCULAR_PARAMS = {"latitude", "longitude", "minradius", "maxradius", "degrees"}
+NONCIRCULAR_PARAMS = {"minlongitude", "maxlongitude", "minlatitude", "maxlatitude"}
+UNSUPPORTED_PARAMS = {"magnitude_type", "events", "contributor"}
+
 
 # ------------------- type aliases (aliai?)
 

--- a/obsplus/exceptions.py
+++ b/obsplus/exceptions.py
@@ -39,6 +39,12 @@ class AmbiguousResponseError(ValueError):
     """
 
 
+class UnsupportedKeyword(TypeError):
+    """
+    Raised when ObsPlus encounters an unexpected keyword.
+    """
+
+
 # --- Warnings
 
 

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -209,10 +209,7 @@ class _IndexCache:
         kwarg_set = set(kwargs)
         if not kwarg_set.issubset(READ_HDF5_KWARGS):
             bad_kwargs = kwarg_set - set(READ_HDF5_KWARGS)
-            msg = (
-                f"The following kwargs are not supported: {bad_kwargs}. "
-                f"Supported kwargs are {kwarg_set}"
-            )
+            msg = f"The following kwargs are not supported: {bad_kwargs}. "
             raise UnsupportedKeyword(msg)
 
     def _set_cache(self, index, starttime, endtime, kwargs):

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -21,7 +21,9 @@ from obsplus.constants import (
     WAVEFORM_NAME_STRUCTURE,
     SMALLDT64,
     LARGEDT64,
+    READ_HDF5_KWARGS,
 )
+from obsplus.exceptions import UnsupportedKeyword
 from obsplus.utils.misc import READ_DICT, _get_path
 from obsplus.utils.mseed import summarize_mseed
 from obsplus.utils.time import to_datetime64, _dict_times_to_ns
@@ -163,11 +165,8 @@ class _IndexCache:
 
     def __call__(self, starttime, endtime, buffer, **kwargs):
         """ get start and end times, perform in kernel lookup """
-        # get defaults if starttime or endtime is none
-        starttime = None if pd.isnull(starttime) else starttime
-        endtime = None if pd.isnull(endtime) else endtime
-        starttime = to_datetime64(starttime or SMALLDT64)
-        endtime = to_datetime64(endtime or LARGEDT64)
+        starttime, endtime = self._get_times(starttime, endtime)
+        self._validate_kwargs(kwargs)
         # find out if the query falls within one cached times
         con1 = self.cache.t1 <= starttime
         con2 = self.cache.t2 >= endtime
@@ -191,8 +190,33 @@ class _IndexCache:
         con2 = index["endtime"] <= (starttime - buffer)
         return index[~(con1 | con2)]
 
+    @staticmethod
+    def _get_times(starttime, endtime):
+        """Return starttimes and endtimes."""
+        # get defaults if starttime or endtime is none
+        starttime = None if pd.isnull(starttime) else starttime
+        endtime = None if pd.isnull(endtime) else endtime
+        starttime = to_datetime64(starttime or SMALLDT64)
+        endtime = to_datetime64(endtime or LARGEDT64)
+        if starttime is not None and endtime is not None:
+            if starttime > endtime:
+                msg = "starttime cannot be greater than endtime."
+                raise ValueError(msg)
+        return starttime, endtime
+
+    def _validate_kwargs(self, kwargs):
+        """Ensure kwargs are supported."""
+        kwarg_set = set(kwargs)
+        if not kwarg_set.issubset(READ_HDF5_KWARGS):
+            bad_kwargs = kwarg_set - set(READ_HDF5_KWARGS)
+            msg = (
+                f"The following kwargs are not supported: {bad_kwargs}. "
+                f"Supported kwargs are {kwarg_set}"
+            )
+            raise UnsupportedKeyword(msg)
+
     def _set_cache(self, index, starttime, endtime, kwargs):
-        """ cache the current index """
+        """Cache the current index """
         ser = pd.Series(
             {
                 "t1": starttime,

--- a/obsplus/utils/misc.py
+++ b/obsplus/utils/misc.py
@@ -31,6 +31,7 @@ from obspy.core.inventory import Station, Channel
 from obspy.io.mseed.core import _read_mseed as mread
 from obspy.io.quakeml.core import _read_quakeml
 
+import obsplus
 from obsplus.constants import NULL_SEED_CODES, NSLC
 
 BASIC_NON_SEQUENCE_TYPE = (int, float, str, bool, type(None))
@@ -584,3 +585,12 @@ def get_version_tuple(version_str: str) -> Tuple[int, int, int]:
     validate_version_str(version_str)
     split = version_str.split(".")
     return int(split[0]), int(split[1]), int(split[2])
+
+
+def strip_prefix(some_str: str, prefixes: Union[str, Collection[str]]) -> str:
+    """Strip a prefix of a string."""
+    out = some_str
+    for prefix in obsplus.utils.iterate(prefixes):
+        if out.startswith(prefix):
+            out = out[len(prefix) :]
+    return out

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -649,7 +649,7 @@ class TestPutEvents:
 
     def test_put_event_no_reference_time(self, ebank):
         """Test that putting an event with no reference time raises."""
-        # get an event with no reference time and no idm
+        # get an event with no reference time and no id
         event = obspy.read_events()[0]
         event.origins.clear()
         event.preferred_origin_id = None

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -16,11 +16,12 @@ from obspy.geodetics import gps2dist_azimuth, kilometer2degrees
 
 import obsplus
 import obsplus.utils.misc
-from obsplus.constants import EVENT_DTYPES
 from obsplus import EventBank, copy_dataset
+from obsplus.constants import EVENT_DTYPES
+from obsplus.exceptions import UnsupportedKeyword
 from obsplus.utils.events import get_preferred
 from obsplus.utils.testing import instrument_methods
-from obsplus.utils.misc import suppress_warnings
+from obsplus.utils.misc import suppress_warnings, get_progressbar
 
 
 def try_permission_sleep(callable, *args, _count=0, **kwargs):
@@ -474,6 +475,11 @@ class TestReadIndexQueries:
         sub = df.select_dtypes([np.datetime64])
         assert {"time", "creation_time", "updated"}.issubset(sub.columns)
 
+    def test_unsupported_params_raise(self, ebank):
+        """Ensure unsupported kwargs raise."""
+        with pytest.raises(UnsupportedKeyword, match="not_a_kwarg"):
+            ebank.read_index(not_a_kwarg=10)
+
 
 class TestGetEvents:
     """ tests for pulling events out of the bank """
@@ -643,7 +649,7 @@ class TestPutEvents:
 
     def test_put_event_no_reference_time(self, ebank):
         """Test that putting an event with no reference time raises."""
-        # get an event with no reference time and no id
+        # get an event with no reference time and no idm
         event = obspy.read_events()[0]
         event.origins.clear()
         event.preferred_origin_id = None
@@ -751,7 +757,7 @@ class TestProgressBar:
 
         def new_get_bar(*args, **kwargs):
             state["called"] = True
-            obsplus.utils.misc.get_progressbar(*args, **kwargs)
+            get_progressbar(*args, **kwargs)
 
         monkeypatch.setattr(obsplus.utils.misc, "get_progressbar", new_get_bar)
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -27,7 +27,7 @@ import obsplus.utils.misc
 import obsplus.utils.pd
 from obsplus.bank.wavebank import WaveBank
 from obsplus.constants import NSLC, EMPTYTD64, WAVEFORM_DTYPES
-from obsplus.exceptions import BankDoesNotExistError
+from obsplus.exceptions import BankDoesNotExistError, UnsupportedKeyword
 from obsplus.utils.misc import iter_files
 from obsplus.utils.time import to_datetime64, to_timedelta64, to_utc
 from obsplus.utils.bank import _natify_paths
@@ -424,6 +424,11 @@ class TestReadIndex:
         default_wbank.update_index()
         df = default_wbank.read_index()
         assert not df.empty
+
+    def test_read_index_raises_on_bad_param(self, default_wbank):
+        """Ensure an unsupported kwarg raises. See #207."""
+        with pytest.raises(UnsupportedKeyword, match="startime"):
+            default_wbank.read_index(startime="2012-01-01")
 
 
 class TestYieldStreams:

--- a/tests/test_events/test_merge.py
+++ b/tests/test_events/test_merge.py
@@ -343,7 +343,7 @@ class TestMergeNewPicks:
         # modify the picks to whole seconds, reset pick IDS
         for pick, _, _ in yield_obj_parent_attr(cat, ev.Pick):
             pick.time -= (pick.time.timestamp) % 1
-            pick.id = ev.ResourceIdentifier(referred_object=pick)
+            pick.resource_id = ev.ResourceIdentifier(referred_object=pick)
         return cat
 
     @pytest.fixture()


### PR DESCRIPTION
This PR ensures both `EventBank` and `WaveBank` raise a newly defined `UnsupportedKerword` exception when, well, an unsupported keyword is used.

Addresses #207
