### PR TITLE
fix seed_string

### DIFF
--- a/obsplus/events/schema.py
+++ b/obsplus/events/schema.py
@@ -260,7 +260,7 @@ class WaveformStreamID(_ObsPyModel):
         # need to add seed_str
         if not seed_str:
             seed = ".".join([values[f"{x}_code"] for x in NSLC])
-            values["seed_str"] = seed
+            values["seed_string"] = seed
             return values
         # need to get other codes from seed_str
         split = seed_str.split(".")


### PR DESCRIPTION
Fixes a small bug in the new event schema where the seed string (network.station.location.channel) was stored as the key "seed_str" rather than "seed_string" on the `WaveformStreamID`.