### PR TITLE
draft version 0.2.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-obsplus master
+obsplus 0.2.0
   - obsplus.structures.fetcher
     * fixed an edge case were banks with only one file failed to return
        streams (#186).


### PR DESCRIPTION
This PR is a draft for version 0.2.0 of ObsPlus. It includes everything up to current master. It is a minor version increment (rather than patch) because of the inclusion of PyDantic.

Is there anything else we should consider doing before publishing the release?
