### PR TITLE
Add check for int overflow in to_datetime64

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,12 @@
+obsplus master
+  - obsplus.utils
+    * Handled edge case of a lower precision datetime64 causing an int64 overflow in `obsplus.utils.time.to_datetime64`. (#224)
+
 obsplus 0.2.0
   - obsplus.structures.fetcher
     * fixed an edge case were banks with only one file failed to return
        streams (#186).
-  - obsplus.structures.dfextractor
+  - obsplus.structures.dxfextractor
     * Handled the case of null integers in the NSLC columns and added a logic
       to force the seed_id column to match the other NSLC columns(#199)
   - obsplus.utils
@@ -49,7 +53,7 @@ obsplus 0.1.1
       of `""` (#178)
   - obsplus.structures.fetcher
     * fixed issue with Fetcher raising Pandas error when an inventory with
-      duplicate chanenls was used (#183, #184).
+      duplicate channels was used (#183, #184).
   - obsplus.utils
     * Refactored df_to_inventory (#182).
     * Refactored compose_docstring and added function for printing dataframe

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 obsplus master
   - obsplus.utils
-    * Handled edge case of a lower precision datetime64 causing an int64 overflow in `obsplus.utils.time.to_datetime64`. (#224)
+    * Handled edge case of a lower precision datetime64 causing an int64
+      overflow in `obsplus.utils.time.to_datetime64`. (#224)
 
 obsplus 0.2.0
   - obsplus.structures.fetcher

--- a/tests/test_utils/test_time_utils.py
+++ b/tests/test_utils/test_time_utils.py
@@ -66,12 +66,33 @@ class TestToNumpyDateTime:
         expected_out = (ts.to_datetime64(),)
         assert out == expected_out
 
-    def test_utc_to_large(self):
+    def test_utc_too_large(self):
         """Test a time larger than can fit into int64."""
         too_big = obspy.UTCDateTime("2600-01-01")
         with pytest.warns(UserWarning):
             out = to_datetime64(too_big)
         assert pd.Timestamp(out).year == 2262
+
+    def test_npdatetime64_too_large(self):
+        """ Test np.datetime64s larger than can fit into int64 """
+        too_big = np.array(
+            [
+                np.datetime64("2300-01-01"),
+                np.datetime64("2020-01-01"),
+                np.datetime64("2500-01-01"),
+            ]
+        )
+        with pytest.warns(UserWarning):
+            out = to_datetime64(too_big)
+        years = out.astype("M8[Y]")
+        assert np.array_equal(
+            years,
+            [
+                np.datetime64("2262", "Y"),
+                np.datetime64("2020", "Y"),
+                np.datetime64("2262", "Y"),
+            ],
+        )
 
     def test_series_to_datetimes(self):
         """Series should be convertible to datetimes, return series """


### PR DESCRIPTION
This PR addresses the bug identified in #224, which would allow for a `np.datetime64` with a lower precision (ex., day) to be converted to nanosecond precision, which resulted in an int64 overflow if the date was larger than the int64 size. This is fixed by adding a check that if the year of the resulting output was less than the input, then the code will warn and assign a date in 2262 (this is the same behavior as what happens when one tries to convert a large UTCDateTime to a datetime64).