### PR TITLE
refactor get_waveforms_bulk

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,10 @@
 obsplus master
   - obsplus.utils
     * Handled edge case of a lower precision datetime64 causing an int64
-      overflow in `obsplus.utils.time.to_datetime64`. (#224)
+      overflow in `obsplus.utils.time.to_datetime64` (#224).
+  - obsplus.WaveBank
+    * Refactored `get_waveforms_bulk` to allow a dataframe if required
+      columns exist (#229).
 
 obsplus 0.2.0
   - obsplus.structures.fetcher

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -513,11 +513,11 @@ class WaveBank(_Bank):
             ind = self.read_index(starttime=t_min, endtime=t_max)
         # for each unique time, apply other filtering conditions and get traces
         unique_times = np.unique(df[["starttime", "endtime"]].values, axis=0)
-        out = obspy.Stream()
+        traces = []
         for utime in unique_times:
-            ar = _filter_index_to_bulk(utime, ind, df, only_time=True)
-            out += self._index2stream(ind[ar], utime[0], utime[1])
-        return out
+            sub = _filter_index_to_bulk(utime, ind, df)
+            traces += self._index2stream(sub, utime[0], utime[1]).traces
+        return obspy.Stream(traces=traces)
 
     @compose_docstring(get_waveforms_params=get_waveforms_parameters)
     def get_waveforms(

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -16,7 +16,6 @@ import pandas as pd
 import tables
 from obspy import UTCDateTime, Stream
 
-import obsplus
 from obsplus.bank.core import _Bank
 from obsplus.constants import (
     NSLC,
@@ -702,7 +701,3 @@ class WaveBank(_Bank):
         if merge:
             st = merge_traces(st, inplace=True)
         return st.sort()
-
-    def get_service_version(self):
-        """ Return the last version of obsplus """
-        return obsplus.__last_version__

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -517,7 +517,7 @@ class WaveBank(_Bank):
         for utime in unique_times:
             sub = _filter_index_to_bulk(utime, ind, df)
             traces += self._index2stream(sub, utime[0], utime[1], merge=False).traces
-        return merge_traces(obspy.Stream(traces=traces))
+        return merge_traces(obspy.Stream(traces=traces), inplace=True)
 
     @compose_docstring(get_waveforms_params=get_waveforms_parameters)
     def get_waveforms(

--- a/obsplus/constants.py
+++ b/obsplus/constants.py
@@ -12,6 +12,7 @@ from typing import (
     TypeVar,
     MutableSequence,
     Iterable,
+    Sequence,
 )
 
 
@@ -309,6 +310,16 @@ WAVEFORM_DTYPES = OrderedDict(
     sampling_period="timedelta64[ns]",
 )
 
+# dtypes for requesting waveforms
+WAVEFORM_REQUEST_DTYPES = {
+    "network": str,
+    "station": str,
+    "location": str,
+    "channel": str,
+    "starttime": "ops_datetime",
+    "endtime": "ops_datetime",
+}
+
 # The datatypes needed for putting waveform info into HDF5
 WAVEFORM_DTYPES_INPUT = MapProxy(
     {i: _DATETIME_TYPE_MAP.get(v, v) for i, v in WAVEFORM_DTYPES.items()}
@@ -382,7 +393,9 @@ wave_type = Union[Stream, Trace]
 utc_able_type = Union[str, UTCDateTime, float, np.datetime64, pd.Timestamp]
 
 # waveform request type (args for get_waveforms)
-waveform_request_type = Tuple[str, str, str, str, utc_able_type, utc_able_type]
+waveform_request_type = Sequence[
+    Tuple[str, str, str, str, utc_able_type, utc_able_type]
+]
 
 # the signature of obspy fdsn client
 wfcli_type = Callable[[str, str, str, str, UTCDateTime, UTCDateTime], Stream]
@@ -431,7 +444,7 @@ column_function_map_type = Mapping[str, series_func_type]
 bank_subpaths_type = Union[path_types, Iterable[path_types]]
 
 # types for bulk waveform requests
-bulk_waveform_arg_type = List[Tuple[str, str, str, str, UTCDateTime, UTCDateTime]]
+bulk_waveform_arg_type = Union[waveform_request_type, pd.DataFrame]
 
 # types which can be used to slice a numpy array
 slice_types = Union[int, slice, List[int], Tuple[int, ...]]

--- a/obsplus/utils/misc.py
+++ b/obsplus/utils/misc.py
@@ -594,3 +594,17 @@ def strip_prefix(some_str: str, prefixes: Union[str, Collection[str]]) -> str:
         if out.startswith(prefix):
             out = out[len(prefix) :]
     return out
+
+
+class ObjectWrapper:
+    """
+    A class for wrapping objects.
+
+    This is useful so array-like things can be packaged into numpy arrays
+    and pandas dataframes.
+    """
+
+    __slots__ = ("data",)  # this speeds up class creation/memory usage
+
+    def __init__(self, data):
+        self.data = data

--- a/obsplus/utils/waveforms.py
+++ b/obsplus/utils/waveforms.py
@@ -269,12 +269,13 @@ def merge_traces(st: trace_sequence, inplace=False) -> obspy.Stream:
         gtraces = [x.data for x in df.trace[ind]]  # unpack traces
         dtype = _get_dtype(gtraces)
         # create list of time, y values, and marker for when values are filled
-        sampling_period = sampling_periods[gnum]
-        t = np.arange(t1[gnum], stop=t2[gnum] + sampling_period, step=sampling_period)
+        sampling_period = sampling_periods[gnum].to_numpy()
+        start, stop = t1[gnum].to_numpy(), t2[gnum].to_numpy()
+        t = np.arange(start=start, stop=stop + sampling_period, step=sampling_period)
         y = np.empty(np.shape(t), dtype=dtype)
         has_filled = np.zeros(len(t), dtype=np.int32)
         for tr in gtraces:
-            start_ind = np.searchsorted(t, to_timedelta64(tr.stats.starttime))
+            start_ind = np.searchsorted(t, to_datetime64(tr.stats.starttime))
             y[start_ind : start_ind + len(tr.data)] = tr.data
             has_filled[start_ind : start_ind + len(tr.data)] = 1
         gtraces[0].data = y

--- a/obsplus/waveforms/get_waveforms.py
+++ b/obsplus/waveforms/get_waveforms.py
@@ -1,21 +1,19 @@
 """
 Module for adding the client-like "get_waveforms" to the Stream class
 """
-from functools import reduce
-from operator import add
 from typing import Optional
 
 import numpy as np
 import obspy
-import pandas as pd
 from obspy import Stream, UTCDateTime as UTC
 
 from obsplus.constants import SMALLDT64, LARGEDT64, NSLC, bulk_waveform_arg_type
-from obsplus.utils.pd import filter_index, _column_contains
-from obsplus.utils.pd import get_seed_id_series
-from obsplus.utils.time import to_datetime64
 from obsplus.utils.time import to_utc
-from obsplus.utils.waveforms import _stream_data_to_df
+from obsplus.utils.waveforms import (
+    _stream_data_to_df,
+    get_waveform_bulk_df,
+    _filter_index_to_bulk,
+)
 
 
 def get_waveforms(
@@ -70,49 +68,26 @@ def get_waveforms_bulk(
         A list of any number of tuples containing the following:
         (network, station, location, channel, starttime, endtime).
     """
-    if not bulk:  # return emtpy waveforms if empty list or None
-        return obspy.Stream()
-
-    def _func(time, ind, df, st):
-        """ return waveforms from df of bulk parameters """
-        match_chars = {"*", "?", "[", "]"}
-        ar = np.ones(len(ind))  # indices of ind to use to load data
-        _t1, _t2 = time[0], time[1]
-        df = df[(df.t1 == time[0]) & (df.t2 == time[1])]
-        # determine which columns use any matching or other select features
-        uses_matches = [_column_contains(df[x], match_chars) for x in NSLC]
-        match_ar = np.array(uses_matches).any(axis=0)
-        df_match = df[match_ar]
-        df_no_match = df[~match_ar]
-        # handle columns that need matches (more expensive)
-        if not df_match.empty:
-            match_bulk = df_match.to_records(index=False)
-            mar = np.array([filter_index(ind, *tuple(b)[:4]) for b in match_bulk])
-            ar = np.logical_and(ar, mar.any(axis=0))
-        # handle columns that do not need matches
-        if not df_no_match.empty:
-            nslc1 = set(get_seed_id_series(df_no_match))
-            nslc2 = get_seed_id_series(ind)
-            ar = np.logical_and(ar, nslc2.isin(nslc1))
-        # get a list of used traces, combine and trim
-        st = obspy.Stream([x for x, y in zip(st, ar) if y])
-        return st.slice(starttime=to_utc(_t1), endtime=to_utc(_t2))
-
     # get a dataframe of stream contents
     index = _stream_data_to_df(stream)
     # get a dataframe of the bulk arguments, convert time to datetime64
-    df = pd.DataFrame(bulk, columns=list(NSLC) + ["utc1", "utc2"])
-    df["t1"] = df["utc1"].apply(to_datetime64)
-    df["t2"] = df["utc2"].apply(to_datetime64)
-    t1, t2 = df["t1"].min(), df["t2"].max()
-    # filter index and streams to be as short as possible
-    needed: pd.DataFrame = ~((index.starttime > t2) | (index.endtime < t1))
-    ind = index[needed]
+    df = get_waveform_bulk_df(bulk)
+    if not len(df):  # return empty string if no bulk reqs provided
+        return obspy.Stream()
+    # filter stream and index to only include requested times
+    min_time, max_time = index["starttime"].min(), index["endtime"].max()
+    needed = ~((index.starttime > max_time) | (index.endtime < min_time))
+    index = index[needed]
     stream = obspy.Stream([tr for tr, bo in zip(stream, needed.values) if bo])
+    # get unique times and check conditions for string columns
     # groupby.apply calls two times for each time set, avoid this.
     unique_times = np.unique(df[["t1", "t2"]].values, axis=0)
-    streams = [_func(time, df=df, ind=ind, st=stream) for time in unique_times]
-    return reduce(add, streams)
+    out = obspy.Stream()
+    for utime in unique_times:
+        ar = _filter_index_to_bulk(utime, index_df=index, bulk_df=df)
+        st = obspy.Stream([x for x, y in zip(stream, ar) if y])
+        out += st.slice(starttime=to_utc(utime[0]), endtime=to_utc(utime[1]))
+    return out
 
 
 # --- add get_waveforms to Stream class

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1280,6 +1280,12 @@ class TestGetGaps:
         gap_df = small_overlap_gaps.get_gaps_df()
         assert len(gap_df) == 0
 
+    def test_min_gap_param(self, gappy_bank):
+        """Ensure the min gap parameter works."""
+        no_gap = gappy_bank.get_gaps_df(min_gap=10000000)
+        with_gap = gappy_bank.get_gaps_df()
+        assert len(no_gap) < len(with_gap)
+
 
 class TestBadInputs:
     """ ensure wavebank handles bad inputs correctly """

--- a/tests/test_utils/test_waveforms_utils.py
+++ b/tests/test_utils/test_waveforms_utils.py
@@ -184,6 +184,14 @@ class TestMergeStream:
         for tr in st_out4:
             assert tr.data.dtype == np.float64
 
+    def test_merge_bingham_st(self, bingham_stream):
+        """Ensure the bingham stream can be merged"""
+        out = merge_traces(bingham_stream, inplace=False)
+        cols = list(NSLC) + ["starttime", "endtime", "gap_time", "gap_samps"]
+        gaps_df = pd.DataFrame(out.get_gaps(), columns=cols)
+        # overlaps are indicated by negative gap times
+        assert (gaps_df["gap_time"] > 0).all()
+
 
 class TestStream2Contiguous:
     """ test the stream2contiguous function works """

--- a/tests/test_waveforms/test_getwaveforms.py
+++ b/tests/test_waveforms/test_getwaveforms.py
@@ -73,16 +73,14 @@ class TestGetWaveforms:
 class TestGetWaveformsBulk:
     """Tests for bulk waveform requests."""
 
-    @pytest.fixture(scope="class")
-    def bingham_st(self, bingham_dataset):
-        """ Return a stream with all data from bingham_test. """
-        return bingham_dataset.waveform_client.get_waveforms()
-
-    @pytest.fixture(scope="class")
-    def bingham_bulk_args(self, bingham_st):
-        """ Return bulk arguments which encompass all of the bingham_test dataset """
+    @pytest.fixture()
+    def bingham_bulk_args(self, bingham_stream):
+        """
+        Return bulk arguments which encompass all of the bingham_test dataset.
+        There is one bulk arg for each trace in bingham_st.
+        """
         bulk = []
-        for tr in bingham_st:
+        for tr in bingham_stream:
             bulk.append(tr.id.split(".") + [tr.stats.starttime, tr.stats.endtime])
         return bulk
 
@@ -104,19 +102,18 @@ class TestGetWaveformsBulk:
         assert isinstance(st, obspy.Stream)
         assert len(st) == 0
 
-    def test_doesnt_modify_original(self, bingham_st, bingham_bulk_args):
+    def test_doesnt_modify_original(self, bingham_stream, bingham_bulk_args):
         """ Ensure the method doesn't modify the original stream or bulk args """
-        st1 = copy.deepcopy(bingham_st)
+        st1 = copy.deepcopy(bingham_stream)
         bulk1 = copy.deepcopy(bingham_bulk_args)
         _ = st1.get_waveforms_bulk(bulk1)
-        assert st1 == bingham_st
+        assert st1 == bingham_stream
         assert bulk1 == bingham_bulk_args
 
-    def test_waveform_bulk(self, bingham_st, bingham_bulk_args):
+    def test_waveform_bulk(self, bingham_stream, bingham_bulk_args):
         """ Test that waveform bulk works on Bingham st """
-        # make a long bulk arg
-        st = bingham_st.get_waveforms_bulk(bingham_bulk_args)
-        assert len(st) == len(bingham_st)
+        st = bingham_stream.get_waveforms_bulk(bingham_bulk_args)
+        assert len(st) == len(bingham_stream)
 
     def test_no_matches(self):
         """ Test waveform bulk when no params meet req. """


### PR DESCRIPTION
I got frustrated that `get_waveforms_bulk` didn't accept a `DataFrame` so now it does (provided it has columns: network, station, location, channel, starttime, endtime).

I also found some parts of the code that were near duplicates between `obsplus.waveforms.get_waveforms_bulk`, which acts on `obspy.Stream` instances, and `obsplus.WaveBank.get_waveforms_bulk` so I cleaned that up too.