### PR TITLE
put_waveforms with gaps

### DIFF
--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -645,13 +645,13 @@ class WaveBank(_Bank):
         for path, tr_list in st_dic.items():
             # make the parent directories if they dont exist
             path.parent.mkdir(exist_ok=True, parents=True)
-            stream = obspy.Stream(traces=tr_list)
+            stream = obspy.Stream(traces=tr_list).split()
             # load the waveforms if the file already exists
             if path.exists():
                 st_existing = obspy.read(str(path))
                 stream += st_existing
             # polish streams and write
-            stream.merge(method=1)
+            stream = merge_traces(stream, inplace=True)
             stream.write(str(path), format="mseed")
             paths.append(path)
         # update the index as the contents have changed


### PR DESCRIPTION
Using `WaveBank`'s `put_waveforms` could previously raise an error related to masked arrays if the waveforms had gaps and used masked arrays. This PR adds a fix (and test) to remedy the problem.