### PR TITLE
use typing protocols

### DIFF
--- a/obsplus/bank/core.py
+++ b/obsplus/bank/core.py
@@ -5,6 +5,7 @@ import tempfile
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
+from inspect import isclass
 from types import MappingProxyType as MapProxy
 from typing import Optional, TypeVar, Mapping, Iterable, Union
 
@@ -233,7 +234,8 @@ class _Bank(ABC):
         # conditions to bail out early
         if bar is False:  # False indicates no bar is to be used
             return None
-        elif isinstance(bar, ProgressBar):  # bar is already instantiated
+        # bar is already instantiated
+        elif isinstance(bar, ProgressBar) and not isclass(bar):
             return bar
         # next, count number of files
         num_files = sum([1 for _ in self._unindexed_iterator()])

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -5,7 +5,7 @@ Note: These are used instead of the ones in obspy.clients.base so the subclass
 hooks can be used.
 """
 from abc import abstractmethod
-from typing import Protocol, runtime_checkable
+from typing_extensions import Protocol, runtime_checkable
 
 import obspy
 import pandas as pd

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -4,42 +4,15 @@ Some common interfaces for event/client types.
 Note: These are used instead of the ones in obspy.clients.base so the subclass
 hooks can be used.
 """
-import inspect
 from abc import abstractmethod
+from typing import Protocol, runtime_checkable
 
 import obspy
 import pandas as pd
 
 
-class _MethodChecker(type):
-    """ class for checking if methods exist """
-
-    def __init__(cls, name, bases, arg_dict):
-        # get all methods defined by class
-        methods = {
-            i for i, v in arg_dict.items() if not i.startswith("_") and callable(v)
-        }
-        cls._required_methods = methods
-
-    def __subclasscheck__(cls, subclass):
-        if not inspect.isclass(subclass):
-            return False
-        methods = {x for B in subclass.__mro__ for x in B.__dict__}
-        if cls._required_methods.issubset(methods):
-            return True
-        return False
-
-    def __instancecheck__(cls, instance):
-        is_instance = not inspect.isclass(instance)
-        # look for defined methods
-        if is_instance and set(cls._required_methods).issubset(dir(instance)):
-            return True
-        # if they do not exist probe for dynamic methods  that meet criteria
-        has_meths = [getattr(instance, x, False) for x in cls._required_methods]
-        return all(has_meths) and is_instance
-
-
-class EventClient(metaclass=_MethodChecker):
+@runtime_checkable
+class EventClient(Protocol):
     """
     Abstract Base Class defining the event client interface.
 
@@ -70,7 +43,8 @@ class EventClient(metaclass=_MethodChecker):
         """ A method which must return events as obspy.Catalog object. """
 
 
-class WaveformClient(metaclass=_MethodChecker):
+@runtime_checkable
+class WaveformClient(Protocol):
     """
     Abstract Base Class defining the waveform client interface.
 
@@ -103,7 +77,8 @@ class WaveformClient(metaclass=_MethodChecker):
         """ A method which must return waveforms as an obspy.Stream. """
 
 
-class StationClient(metaclass=_MethodChecker):
+@runtime_checkable
+class StationClient(Protocol):
     """
     Abstract Base Class defining the station client interface.
 
@@ -132,7 +107,8 @@ class StationClient(metaclass=_MethodChecker):
         """ A method which must return an inventory object. """
 
 
-class BankType(metaclass=_MethodChecker):
+@runtime_checkable
+class BankType(Protocol):
     """ an object that looks like a bank """
 
     @abstractmethod
@@ -140,7 +116,8 @@ class BankType(metaclass=_MethodChecker):
         """ A method which must return a dataframe of index contents. """
 
 
-class ProgressBar(metaclass=_MethodChecker):
+@runtime_checkable
+class ProgressBar(Protocol):
     """
     A class that behaves like the progressbar2.ProgressBar class.
     """

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -25,7 +25,6 @@ class EventClient(Protocol):
     >>> import obspy
     >>> # EventBank is a subclass of EventClient
     >>> assert issubclass(obsplus.EventBank, EventClient)
-    >>> assert issubclass(obspy.Catalog, EventClient)
     >>> # A string has no `get_events` so it is not a subclass/instance
     >>> assert not issubclass(str, EventClient)
     >>> assert not isinstance('string', EventClient)
@@ -55,7 +54,6 @@ class WaveformClient(Protocol):
     >>> import obspy
     >>> # WaveBank/Stream are subclasses of WaveformClient
     >>> assert issubclass(obsplus.WaveBank, WaveformClient)
-    >>> assert issubclass(obspy.Stream, WaveformClient)
     >>> # A string has no `get_waveforms` so it is not a subclass/instance
     >>> assert not issubclass(str, WaveformClient)
     >>> assert not isinstance('string', WaveformClient)

--- a/obsplus/interfaces.py
+++ b/obsplus/interfaces.py
@@ -26,8 +26,6 @@ class EventClient(Protocol):
     >>> # EventBank is a subclass of EventClient
     >>> assert issubclass(obsplus.EventBank, EventClient)
     >>> assert issubclass(obspy.Catalog, EventClient)
-    >>> # a catalog is an instance of EventClient
-    >>> assert isinstance(obspy.read_events(), EventClient)
     >>> # A string has no `get_events` so it is not a subclass/instance
     >>> assert not issubclass(str, EventClient)
     >>> assert not isinstance('string', EventClient)
@@ -61,8 +59,6 @@ class WaveformClient(Protocol):
     >>> # A string has no `get_waveforms` so it is not a subclass/instance
     >>> assert not issubclass(str, WaveformClient)
     >>> assert not isinstance('string', WaveformClient)
-    >>> # A stream is a subclass of WaveformClient
-    >>> assert isinstance(obspy.read(), WaveformClient)
     >>> # this works on any class with a get_waveforms method
     >>> class NewWaveformClientThing:
     ...     def get_waveforms(self, *args, **kwargs):
@@ -131,7 +127,7 @@ class ProgressBar(Protocol):
         """ Puts the progress bar in the finished state. """
 
 
-# register virtual subclasses
-# WaveformClient.register(obspy.Stream)
-# EventClient.register(obspy.Catalog)
-# StationClient.register(obspy.Inventory)
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -35,18 +35,16 @@ def iris_client():
 class TestEventClient:
     """Tests for event client interface."""
 
-    not_event_client_instances = ["a", 1, EventBank]
+    not_event_client_instances = ["a", 1]
 
     def test_fdsn_isinstance(self, iris_client):
         """ ensure the client is an instance of EventClient """
         assert isinstance(iris_client, EventClient)
-        assert not isinstance(10, EventClient)
 
     def test_fdsn_issubclass(self):
         """ Test client FDSN client meets EventClient interface. """
         issubclass(str, EventClient)
         assert issubclass(Client, EventClient)
-        assert not issubclass(str, EventClient)
 
     def test_catalog(self):
         """ ensure a events is also an EventClient """
@@ -147,11 +145,6 @@ class TestBar:
 
         assert issubclass(MyBar, ProgressBar)
         assert isinstance(MyBar(), ProgressBar)
-        # the class should not be an instance
-        isinstance(MyBar, ProgressBar)
-        assert not isinstance(MyBar, ProgressBar)
-        # the instance should not be a subclass
-        assert not issubclass(MyBar(), ProgressBar)
 
     def test_malformed_progress_bar(self):
         """


### PR DESCRIPTION
This PR replaces the hinky metaclass in `obsplus.interfaces` with `Protocol` and friends which is included in the typing module of the standard library. Since we already using the backported typing package `typing_extentions` we don't even need to bump the required python version.

See #228 