### PR TITLE
remove to_numpy

### DIFF
--- a/obsplus/utils/waveforms.py
+++ b/obsplus/utils/waveforms.py
@@ -269,8 +269,8 @@ def merge_traces(st: trace_sequence, inplace=False) -> obspy.Stream:
         gtraces = [x.data for x in df.trace[ind]]  # unpack traces
         dtype = _get_dtype(gtraces)
         # create list of time, y values, and marker for when values are filled
-        sampling_period = sampling_periods[gnum].to_numpy()
-        start, stop = t1[gnum].to_numpy(), t2[gnum].to_numpy()
+        sampling_period = sampling_periods[gnum].to_timedelta64()
+        start, stop = t1[gnum].to_datetime64(), t2[gnum].to_datetime64()
         t = np.arange(start=start, stop=stop + sampling_period, step=sampling_period)
         y = np.empty(np.shape(t), dtype=dtype)
         has_filled = np.zeros(len(t), dtype=np.int32)


### PR DESCRIPTION
replaces `to_numpy` in favor of `to_datetime64` and `to_timedelta64`