### PR TITLE
Allow duplicate '?' phases

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy<1.3.1
+  - numpy<1.21
   - scipy
   - obspy
   - pytables

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - numpy
+  - numpy<1.3.1
   - scipy
   - obspy
   - pytables
-  - pandas
+  - pandas<1.4
   - pytest
   - pandoc
   - pydantic

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ target/
 # pycharm
 .idea
 
+# vscode
+.vscode/
+
 # Ipython stuff
 .ipynb_checkpoints
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
 obsplus master
+  - obsplus.events.validate
+    * Loosened check for duplicate pick ids to only check for duplicate
+      P and S phases
+    * Made amplitude time window check skip over rejected amplitudes
   - obsplus.utils
     * Handled edge case of a lower precision datetime64 causing an int64
       overflow in `obsplus.utils.time.to_datetime64` (#224).

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -421,7 +421,7 @@ class WaveBank(_Bank):
         """
 
         def _get_gap_dfs(df, min_gap):
-            """ Apply me to each group of seed_id dataframes"""
+            """Apply me to each group of seed_id dataframes"""
             if not len(df):
                 return pd.DataFrame(
                     columns=df.columns.union(["starttime", "endtime", "gap_duration"])

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -421,7 +421,11 @@ class WaveBank(_Bank):
         """
 
         def _get_gap_dfs(df, min_gap):
-            """function to apply to each group of seed_id dataframes"""
+            """ Apply me to each group of seed_id dataframes"""
+            if not len(df):
+                return pd.DataFrame(
+                    columns=df.columns.union(["starttime", "endtime", "gap_duration"])
+                )
             # get the min gap
             if min_gap is None:
                 min_gap = 1.5 * df["sampling_period"].iloc[0]

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -110,18 +110,19 @@ def check_duplicate_picks(event: Event):
             f"Duplicate {phase_hint} picks found\n" f"event_id: {event_id}, "
         )
 
-    # A dict of {phase: column that cant be duplicated}  <- is this comment
-    #  correct, and if so, is there a less confusing way to do this?
-    phase_duplicates = {"IAML": None, "AML": None, "?": None}
+    # A dict of {phase: column that cant be duplicated}
+    phase_duplicates = {"P": NSLC[:-1], "p": NSLC[:-1], "S": NSLC[:-1], "s": NSLC[:-1]}
     # first get dataframe of picks, filter out rejected
     pdf = obsplus.picks_to_df(event)
     pdf = pdf.loc[pdf.evaluation_status != "rejected"]
     # add column for network.station.location
     event_id = str(event.resource_id)
-    for phase_hint, sub_df in pdf.groupby("phase_hint"):
-        # default to comparing network, station, location
-        subset = phase_duplicates.get(phase_hint, NSLC[:-1])
-        dup_picks(sub_df, phase_hint, subset=subset)
+    # Go through each of phase duplicates and compare against the pick dataframe
+    pick_gb = pdf.groupby("phase_hint")
+    for ph, cols in phase_duplicates.items():
+        if ph not in pick_gb.groups:
+            continue
+        dup_picks(pick_gb.get_group(ph), ph, subset=cols)
 
 
 @validator("obsplus", Event)
@@ -260,8 +261,8 @@ def check_amp_times_contain_pick_time(event: Event):
     """
     bad = []
     for amp in event.amplitudes:
-        if amp.time_window is None:
-            continue
+        if (amp.time_window is None) or (amp.evaluation_status == "rejected"):
+            continue  # We don't care about it, skip it.
         amp_t = amp.time_window.reference
         pick = amp.pick_id.get_referred_object()
         if (amp_t is None) or (amp_t != pick.time):

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -110,8 +110,8 @@ def check_duplicate_picks(event: Event):
             f"Duplicate {phase_hint} picks found\n" f"event_id: {event_id}, "
         )
 
-    # A dict of {phase: column that cant be duplicated}
-    phase_duplicates = {"IAML": None, "AML": None}
+    # A dict of {phase: column that cant be duplicated}  <- is this comment correct, and if so, is there a less confusing way to do this?
+    phase_duplicates = {"IAML": None, "AML": None, "?": None}
     # first get dataframe of picks, filter out rejected
     pdf = obsplus.picks_to_df(event)
     pdf = pdf.loc[pdf.evaluation_status != "rejected"]

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -110,7 +110,8 @@ def check_duplicate_picks(event: Event):
             f"Duplicate {phase_hint} picks found\n" f"event_id: {event_id}, "
         )
 
-    # A dict of {phase: column that cant be duplicated}  <- is this comment correct, and if so, is there a less confusing way to do this?
+    # A dict of {phase: column that cant be duplicated}  <- is this comment
+    #  correct, and if so, is there a less confusing way to do this?
     phase_duplicates = {"IAML": None, "AML": None, "?": None}
     # first get dataframe of picks, filter out rejected
     pdf = obsplus.picks_to_df(event)

--- a/obsplus/utils/mseed.py
+++ b/obsplus/utils/mseed.py
@@ -26,7 +26,7 @@ def _get_lil(mseed_object):
     selections = None
 
     length = os.path.getsize(mseed_object)
-    assert 128 < length < 2 ** 31, "data length is outside of the save range"
+    assert 128 < length < (2 ** 31), "data length is outside of the save range"
 
     # Assume a file was passed
     bfr_np = np.fromfile(mseed_object, dtype=np.int8)

--- a/obsplus/utils/mseed.py
+++ b/obsplus/utils/mseed.py
@@ -26,7 +26,7 @@ def _get_lil(mseed_object):
     selections = None
 
     length = os.path.getsize(mseed_object)
-    assert 128 < length < (2 ** 31), "data length is outside of the save range"
+    assert 128 < length < 2**31, "data length is outside of the save range"
 
     # Assume a file was passed
     bfr_np = np.fromfile(mseed_object, dtype=np.int8)

--- a/obsplus/utils/stations.py
+++ b/obsplus/utils/stations.py
@@ -108,7 +108,7 @@ class _InventoryConstructor:
             df["end_date"] = df["end_date"].fillna(default_end)
 
         for ind, df_sub in df.groupby(cols):
-            # replace NaN values
+            # replace NaN values  # this is causing a problem with pandas 1.4 for some reason
             if isnan.any().any():
                 df_sub[isnan.loc[df_sub.index]] = np.nan
             yield ind, df_sub

--- a/obsplus/utils/stations.py
+++ b/obsplus/utils/stations.py
@@ -108,7 +108,7 @@ class _InventoryConstructor:
             df["end_date"] = df["end_date"].fillna(default_end)
 
         for ind, df_sub in df.groupby(cols):
-            # replace NaN values  # this is causing a problem with pandas 1.4 for some reason
+            # replace NaN values  # this is causing a problem with pandas 1.4
             if isnan.any().any():
                 df_sub[isnan.loc[df_sub.index]] = np.nan
             yield ind, df_sub

--- a/tests/test_events/test_event_validate.py
+++ b/tests/test_events/test_event_validate.py
@@ -149,7 +149,7 @@ class TestValidateCatalog:
 
     @pytest.fixture
     def cat_duplicate_unknown_phase_hints(self, cat1):
-        """ Create duplicate picks with unknown phase hints"""
+        """Create duplicate picks with unknown phase hints"""
         cat = cat1.copy()
         eve = cat[0]
         eve.picks.append(

--- a/tests/test_events/test_event_validate.py
+++ b/tests/test_events/test_event_validate.py
@@ -152,8 +152,24 @@ class TestValidateCatalog:
         """ Create duplicate picks with unknown phase hints"""
         cat = cat1.copy()
         eve = cat[0]
-        eve.picks.append(ev.Pick(time=obspy.UTCDateTime(), waveform_id=ev.WaveformStreamID(network_code="UK", station_code="STA", channel_code="HHZ"), phase_hint="?"))
-        eve.picks.append(ev.Pick(time=obspy.UTCDateTime(), waveform_id=ev.WaveformStreamID(network_code="UK", station_code="STA", channel_code="HHN"), phase_hint="?"))
+        eve.picks.append(
+            ev.Pick(
+                time=obspy.UTCDateTime(),
+                waveform_id=ev.WaveformStreamID(
+                    network_code="UK", station_code="STA", channel_code="HHZ"
+                ),
+                phase_hint="?",
+            )
+        )
+        eve.picks.append(
+            ev.Pick(
+                time=obspy.UTCDateTime(),
+                waveform_id=ev.WaveformStreamID(
+                    network_code="UK", station_code="STA", channel_code="HHN"
+                ),
+                phase_hint="?",
+            )
+        )
         return cat
 
     # tests

--- a/tests/test_events/test_event_validate.py
+++ b/tests/test_events/test_event_validate.py
@@ -147,6 +147,15 @@ class TestValidateCatalog:
         cat1[0].picks[1].waveform_id.location_code = None
         return validate_catalog(cat1)
 
+    @pytest.fixture
+    def cat_duplicate_unknown_phase_hints(self, cat1):
+        """ Create duplicate picks with unknown phase hints"""
+        cat = cat1.copy()
+        eve = cat[0]
+        eve.picks.append(ev.Pick(time=obspy.UTCDateTime(), waveform_id=ev.WaveformStreamID(network_code="UK", station_code="STA", channel_code="HHZ"), phase_hint="?"))
+        eve.picks.append(ev.Pick(time=obspy.UTCDateTime(), waveform_id=ev.WaveformStreamID(network_code="UK", station_code="STA", channel_code="HHN"), phase_hint="?"))
+        return cat
+
     # tests
     def test_pcat1_cleared_preferreds(self, cat1_cleared_preferreds):
         """cleared preferreds should be reset to last in list"""
@@ -315,6 +324,13 @@ class TestValidateCatalog:
         cat[0].picks.append(pick)
         # this should not raise
         validate_catalog(cat)
+
+    def test_duplicate_unknown_picks_ok(self, cat_duplicate_unknown_phase_hints):
+        """
+        Picks that are unknown (have a "?" for the phase hint) shouldn't count as duplicated
+        """
+        # this should not raise
+        validate_catalog(cat_duplicate_unknown_phase_hints)
 
     def test_duplicate_station_different_network(self, cat1):
         """


### PR DESCRIPTION
This is a small change to permit duplicate '?' phases in the default validators. As a side note, the behavior on this particular check feels a bit restrictive. Would it be better to prevent duplicate P & S phases and allow everything else rather than the current behavior? @d-chambers 