### PR TITLE
bump python versions

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -55,6 +55,7 @@ def attach_all_resource_ids(event: Event):
     for rid, parent, attr in yield_obj_parent_attr(event, ResourceIdentifier):
         if attr != "resource_id" and rid.id in rid_to_object:
             rid.set_referred_object(rid_to_object[rid.id])
+    event.scope_resource_ids()
 
 
 @validator("obsplus", Event)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 from setuptools import setup
 
 # define python versions
-python_version = (3, 6)  # tuple of major, minor version requirement
+python_version = (3, 7)  # tuple of major, minor version requirement
 python_version_str = str(python_version[0]) + "." + str(python_version[1])
 
 # produce an error message if the python version is less than required
@@ -120,9 +120,9 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
     ],
     test_suite="tests",


### PR DESCRIPTION
This PR bumps the supported python versions from 3.6-3.8 to 3.8-3.9. 