### PR TITLE
Bank paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==21.5b1]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,15 @@
 obsplus master
+  - obsplus.bank
+    Better support for bank paths on Windows See # 256.
   - obsplus.events.validate
     * Loosened check for duplicate pick ids to only check for duplicate
       P and S phases
     * Made amplitude time window check skip over rejected amplitudes
   - obsplus.utils
     * Fix issue #249 to allow pandas 1.4+
-  - Dropped python 3.7 from test matrix to keep size managable.
+  - versions
+    Dropped python 3.7 from test matrix to keep size managable.
+    Added python 3.10 to test matrix.
 
 obsplus 0.2.2
   - Added support for python 3.9, dropped python 3.6

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -269,17 +269,13 @@ class EventBank(_Bank):
         {bar_parameter_description}
         {paths_description}
         """
-        bank_path = str(self.bank_path)
-
         self._enforce_min_version()  # delete index if schema has changed
         # create iterator  and lists for storing output
         update_time = time.time()
         # create an iterator which yields files to update and updates bar
         file_yielder = self._unindexed_iterator(paths=paths)
         update_file_feeder = self._measure_iterator(file_yielder, bar)
-        new_func = partial(
-            self._get_cat_update_time_path, format=self.format
-        )
+        new_func = partial(self._get_cat_update_time_path, format=self.format)
         # create iterator, loop over it in chunks until it is exhausted
         iterator = self._map(new_func, update_file_feeder)
         events_remain = True

--- a/obsplus/bank/eventbank.py
+++ b/obsplus/bank/eventbank.py
@@ -2,6 +2,7 @@
 Class for interacting with events on a filesystem.
 """
 import inspect
+import os
 import time
 from concurrent.futures import Executor
 from functools import reduce, partial
@@ -277,7 +278,7 @@ class EventBank(_Bank):
         file_yielder = self._unindexed_iterator(paths=paths)
         update_file_feeder = self._measure_iterator(file_yielder, bar)
         new_func = partial(
-            self._get_cat_update_time_path, bank_path=bank_path, format=self.format
+            self._get_cat_update_time_path, format=self.format
         )
         # create iterator, loop over it in chunks until it is exhausted
         iterator = self._map(new_func, update_file_feeder)
@@ -287,13 +288,12 @@ class EventBank(_Bank):
         return self
 
     @staticmethod
-    def _get_cat_update_time_path(path, bank_path, format):
+    def _get_cat_update_time_path(path, format):
         """Function to yield events, update_time and paths."""
         # NOTE: This function must be static to avoid pickling the attached
         # executor. (see #158).
         cat = try_read_catalog(path, format=format)
         update_time = getmtime(path)
-        path = path.replace(bank_path, "")
         return cat, update_time, path
 
     def _index_from_iterable(self, iterable, update_time):
@@ -315,7 +315,7 @@ class EventBank(_Bank):
         # add new events to database
         df = obsplus.events.pd._default_cat_to_df(events)
         df["updated"] = to_datetime64(update_times)
-        df["path"] = _remove_base_path(pd.Series(paths, dtype=object))
+        df["path"] = _remove_base_path(pd.Series(paths, dtype=object), self.bank_path)
         if len(df):
             df = _time_cols_to_ints(df)
             df_to_write = self._prepare_dataframe(df, EVENT_TYPES_INPUT)
@@ -397,7 +397,7 @@ class EventBank(_Bank):
         ind = self.read_index(**kwargs)
         eids = ind["event_id"]
         file_paths = ind["path"]
-        paths = str(self.bank_path) + _natify_paths(file_paths)
+        paths = str(self.bank_path) + os.sep + _natify_paths(file_paths)
         paths.drop_duplicates(inplace=True)
         read_func = partial(try_read_catalog, format=self.format)
         # Divide work evenly between workers, with a min chunksize of 1.
@@ -510,7 +510,7 @@ class EventBank(_Bank):
         rid = str(event.resource_id)
         if rid in df.index:  # event needs to be updated
             path = df.loc[rid, "path"]
-            save_path = bank_path + path
+            save_path = bank_path + os.sep + path
             if not overwrite_existing:  # dont update existing
                 return
         else:  # event file does not yet exist

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -451,7 +451,7 @@ class WaveBank(_Bank):
         # get index and group by NSLC and sampling_period
         index = self.read_index(*args, **kwargs)
         group_names = list(NSLC) + ["sampling_period"]  # include period
-        group = index.groupby(group_names, as_index=False)
+        group = index.groupby(group_names, as_index=False, group_keys=False)
         out = group.apply(_get_gap_dfs, min_gap=min_gap)
         if out.empty:  # if not gaps return empty dataframe with needed cols
             return pd.DataFrame(columns=self._gap_columns)
@@ -481,7 +481,7 @@ class WaveBank(_Bank):
         # merge gap dataframe with availability dataframe, add uptime and %
         df = pd.merge(avail, gap_total_df, how="outer")
         # fill any Nan in gap_duration with empty timedelta
-        df.loc[:, "gap_duration"] = df["gap_duration"].fillna(EMPTYTD64)
+        df["gap_duration"] = df["gap_duration"].fillna(EMPTYTD64)
         df["uptime"] = df["duration"] - df["gap_duration"]
         df["availability"] = df["uptime"] / df["duration"]
         return df

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -1,6 +1,7 @@
 """
 A local database for waveform formats.
 """
+import os
 import time
 from collections import defaultdict
 from concurrent.futures import Executor
@@ -667,7 +668,7 @@ class WaveBank(_Bank):
     def _index2stream(self, index, starttime=None, endtime=None, merge=True) -> Stream:
         """return the waveforms in the index"""
         # get abs path to each datafame
-        files: pd.Series = (str(self.bank_path) + index.path).unique()
+        files: pd.Series = (str(self.bank_path) + os.sep + index.path).unique()
         # make sure start and endtimes are in UTCDateTime
         starttime = to_utc(starttime) if starttime else None
         endtime = to_utc(endtime) if endtime else None

--- a/obsplus/events/get_events.py
+++ b/obsplus/events/get_events.py
@@ -143,7 +143,7 @@ def _get_ids(df, kwargs) -> set:
                 filt &= df["event_id"] == str(value)
         df = df[filt]
     limit = kwargs.get("limit", len(df))
-    return set(df.event_id[:limit])
+    return set(df["event_id"].values[:limit])
 
 
 def _handle_dateline_transversal(filt, df, kwargs):

--- a/obsplus/events/validate.py
+++ b/obsplus/events/validate.py
@@ -158,7 +158,7 @@ def check_pick_order(event: Event):
     # get series of network, station
     ns = get_seed_id_series(pdf, subset=NSLC[:3])
     # Checking that picks are in acceptable order
-    gb, sp, ap = pdf.groupby(ns), [], []
+    gb, sp, ap = pdf.groupby(ns, group_keys=False), [], []
     gb.apply(pick_order, sp, ap)
     assert len(sp) == 0, "S pick found before P pick:\n" f"station/s: {sp}"
     assert len(ap) == 0, "amplitude pick found before P pick:\n" f"seed_id/s: {ap}"

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -140,7 +140,7 @@ def _remove_base_path(series: pd.Series, base="") -> pd.Series:
         return series
     unix_paths = series.str.replace(os.sep, "/")
     unix_base_path = str(base).replace(os.sep, "/")
-    return unix_paths.str.replace(unix_base_path, "")
+    return unix_paths.str.replace(unix_base_path + os.sep, "")
 
 
 def _natify_paths(series: pd.Series) -> pd.Series:

--- a/obsplus/utils/bank.py
+++ b/obsplus/utils/bank.py
@@ -140,7 +140,8 @@ def _remove_base_path(series: pd.Series, base="") -> pd.Series:
         return series
     unix_paths = series.str.replace(os.sep, "/", regex=False)
     unix_base_path = str(base).replace(os.sep, "/")
-    return unix_paths.str.replace(unix_base_path + os.sep, "", regex=False)
+    # NOTE: this uses "/" not os.sep because we've already swapped out os.sep
+    return unix_paths.str.replace(unix_base_path + "/", "", regex=False)
 
 
 def _natify_paths(series: pd.Series) -> pd.Series:

--- a/obsplus/utils/stations.py
+++ b/obsplus/utils/stations.py
@@ -28,6 +28,7 @@ from obsplus.interfaces import StationClient
 from obsplus.utils import get_nslc_series
 from obsplus.utils.docs import compose_docstring, format_dtypes
 from obsplus.utils.time import to_utc
+from obsplus.utils.misc import suppress_warnings
 
 LARGE_NUMBER = obspy.UTCDateTime("3000-01-01").timestamp
 
@@ -107,14 +108,19 @@ class _InventoryConstructor:
         if "end_date" in columns:
             df["end_date"] = df["end_date"].fillna(default_end)
 
-        for ind, df_sub in df.groupby(cols):
-            # replace NaN values
-            sub_nan = isnan.loc[df_sub.index]
-            has_nan = sub_nan.any(axis=0)
-            cols_with_nan = has_nan[has_nan].index
-            for col in cols_with_nan:
-                df_sub.loc[sub_nan[col].values, col] = np.nan
-            yield ind, df_sub
+        with suppress_warnings(UserWarning):
+            for ind, df_sub in df.groupby(cols):
+                # Pandas added an annoying warning about iterating groupbys with
+                # len one. In the future ind will be a tuple, so future proofing.
+                # See pandas/issues/42795
+                ind = ind[0] if isinstance(ind, tuple) and len(ind) == 1 else ind
+                # replace NaN values
+                sub_nan = isnan.loc[df_sub.index]
+                has_nan = sub_nan.any(axis=0)
+                cols_with_nan = has_nan[has_nan].index
+                for col in cols_with_nan:
+                    df_sub.loc[sub_nan[col].values, col] = np.nan
+                yield ind, df_sub
 
     def _get_kwargs(self, series, key_mapping):
         """create the kwargs from a series and key mapping."""

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -149,7 +149,10 @@ class TestBankBasics:
 
     @pytest.fixture
     def legacy_path_index(self, ebank, monkeypatch):
-        """Overwrite 'read_index' to return an index with leading '/'s in the file paths"""
+        """
+        Overwrite 'read_index' to return an index with leading '/'s in
+        the file paths.
+        """
         ind = ebank.read_index()
         ind["path"] = "/" + ind["path"]
 
@@ -157,7 +160,7 @@ class TestBankBasics:
             return ind
 
         monkeypatch.setattr(ebank, "read_index", read_index)
-        yield  # <- is this necessary? it's been a little while
+        yield
         monkeypatch.undo()
 
     def test_has_attrs(self, bing_ebank):
@@ -372,7 +375,8 @@ class TestBankBasics:
 
     def test_file_path_reconstruction(self, ebank):
         """
-        It should be possible to get the full path of a file in the index using pathlib's "/" overloading
+        It should be possible to get the full path of a file in the index using
+        pathlib's "/" overloading
         """
         bank_path = ebank.bank_path
         index = ebank.read_index()

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -149,7 +149,7 @@ class TestBankBasics:
 
     @pytest.fixture
     def legacy_path_index(self, ebank, monkeypatch):
-        """ Overwrite 'read_index' to return an index with leading '/'s in the file paths """
+        """Overwrite 'read_index' to return an index with leading '/'s in the file paths"""
         ind = ebank.read_index()
         ind["path"] = "/" + ind["path"]
 
@@ -380,7 +380,7 @@ class TestBankBasics:
         assert (bank_path / pth).is_file()
 
     def test_file_path_legacy_index(self, ebank, legacy_path_index):
-        """ Verify backwards compatibility for relative paths with leading '/' """
+        """Verify backwards compatibility for relative paths with leading '/'"""
         cat = ebank.get_events()
         assert len(cat)
 

--- a/tests/test_bank/test_eventbank.py
+++ b/tests/test_bank/test_eventbank.py
@@ -147,6 +147,19 @@ class TestBankBasics:
         # init, update, return bank
         return obsplus.EventBank(tmp_path).update_index()
 
+    @pytest.fixture
+    def legacy_path_index(self, ebank, monkeypatch):
+        """ Overwrite 'read_index' to return an index with leading '/'s in the file paths """
+        ind = ebank.read_index()
+        ind["path"] = "/" + ind["path"]
+
+        def read_index(*args, **kwargs):
+            return ind
+
+        monkeypatch.setattr(ebank, "read_index", read_index)
+        yield  # <- is this necessary? it's been a little while
+        monkeypatch.undo()
+
     def test_has_attrs(self, bing_ebank):
         """ensure all the required attrs exist"""
         for attr in self.expected_attrs:
@@ -357,6 +370,20 @@ class TestBankBasics:
         bank = EventBank(path, path_structure="")
         assert bank.path_structure == ""
 
+    def test_file_path_reconstruction(self, ebank):
+        """
+        It should be possible to get the full path of a file in the index using pathlib's "/" overloading
+        """
+        bank_path = ebank.bank_path
+        index = ebank.read_index()
+        pth = index.iloc[0].path
+        assert (bank_path / pth).is_file()
+
+    def test_file_path_legacy_index(self, ebank, legacy_path_index):
+        """ Verify backwards compatibility for relative paths with leading '/' """
+        cat = ebank.get_events()
+        assert len(cat)
+
 
 class TestEventIdInBank:
     """Tests for determining if ids are in the bank."""
@@ -531,7 +558,7 @@ class TestGetEvents:
         """Create an event bank and delete all but 1 qml."""
         df = ebank.read_index()
         for path in df["path"][:-1]:
-            file_path = Path(str(ebank.bank_path) + path)
+            file_path = ebank.bank_path / path
             assert file_path.exists()
             file_path.unlink()
         return ebank
@@ -695,7 +722,7 @@ class TestPutEvents:
         """Ensure events are not squashed when overwrite_existing=False"""
         # get mtimes of files in event bank
         df = ebank.read_index()
-        files = [ebank.bank_path / x[1:] for x in df["path"]]
+        files = [ebank.bank_path / x for x in df["path"]]
         assert all([x.exists() for x in files])
         mtimes_1 = [x.stat().st_mtime for x in files]
         # put the same events back into the bank

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -147,7 +147,10 @@ class TestBankBasics:
 
     @pytest.fixture
     def legacy_path_index(self, default_wbank, monkeypatch):
-        """Overwrite 'read_index' to return an index with leading '/'s in the file paths"""
+        """
+        Overwrite 'read_index' to return an index with leading '/'s in the
+        file paths.
+        """
         ind = default_wbank.read_index()
         ind["path"] = "/" + ind["path"]
 
@@ -155,7 +158,7 @@ class TestBankBasics:
             return ind
 
         monkeypatch.setattr(default_wbank, "read_index", read_index)
-        yield  # <- is this necessary? it's been a little while
+        yield
         monkeypatch.undo()
 
     # tests
@@ -329,7 +332,8 @@ class TestBankBasics:
 
     def test_file_path_reconstruction(self, default_wbank):
         """
-        It should be possible to get the full path of a file in the index using pathlib's "/" overloading
+        It should be possible to get the full path of a file in the
+        index using pathlib's "/" overloading
         """
         bank_path = default_wbank.bank_path
         index = default_wbank.read_index()

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -147,7 +147,7 @@ class TestBankBasics:
 
     @pytest.fixture
     def legacy_path_index(self, default_wbank, monkeypatch):
-        """ Overwrite 'read_index' to return an index with leading '/'s in the file paths """
+        """Overwrite 'read_index' to return an index with leading '/'s in the file paths"""
         ind = default_wbank.read_index()
         ind["path"] = "/" + ind["path"]
 
@@ -157,7 +157,6 @@ class TestBankBasics:
         monkeypatch.setattr(default_wbank, "read_index", read_index)
         yield  # <- is this necessary? it's been a little while
         monkeypatch.undo()
-
 
     # tests
     def test_type(self, ta_bank):
@@ -338,7 +337,7 @@ class TestBankBasics:
         assert (bank_path / pth).is_file()
 
     def test_file_path_legacy_index(self, default_wbank, legacy_path_index):
-        """ Verify backwards compatibility for relative paths with leading '/' """
+        """Verify backwards compatibility for relative paths with leading '/'"""
         st = default_wbank.get_waveforms()
         assert len(st)
 

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -145,6 +145,20 @@ class TestBankBasics:
         assert Path(default_wbank.bank_path).exists()
         return default_wbank
 
+    @pytest.fixture
+    def legacy_path_index(self, default_wbank, monkeypatch):
+        """ Overwrite 'read_index' to return an index with leading '/'s in the file paths """
+        ind = default_wbank.read_index()
+        ind["path"] = "/" + ind["path"]
+
+        def read_index(*args, **kwargs):
+            return ind
+
+        monkeypatch.setattr(default_wbank, "read_index", read_index)
+        yield  # <- is this necessary? it's been a little while
+        monkeypatch.undo()
+
+
     # tests
     def test_type(self, ta_bank):
         """make sure ta_test bank is a bank"""
@@ -165,10 +179,10 @@ class TestBankBasics:
         # make sure all file paths are in the index
         index = ta_bank_no_index.read_index()
         index_paths = _natify_paths(index["path"])
-        file_paths = set(str(ta_bank_no_index.bank_path) + index_paths)
+        file_paths = set([ta_bank_no_index.bank_path / pth for pth in index_paths])
         for file_path in iter_files(str(bank_path), ext="mseed"):
             # go up two levels to match path reference
-            file_path = os.path.abspath(file_path)
+            file_path = Path(file_path)
             assert file_path in file_paths
 
     def test_update_index_bumps_only_for_new_files(self, ta_bank_index):
@@ -313,6 +327,20 @@ class TestBankBasics:
         path = Path(tmpdir) / "path_structure"
         bank = WaveBank(path, path_structure="")
         assert bank.path_structure == ""
+
+    def test_file_path_reconstruction(self, default_wbank):
+        """
+        It should be possible to get the full path of a file in the index using pathlib's "/" overloading
+        """
+        bank_path = default_wbank.bank_path
+        index = default_wbank.read_index()
+        pth = index.iloc[0].path
+        assert (bank_path / pth).is_file()
+
+    def test_file_path_legacy_index(self, default_wbank, legacy_path_index):
+        """ Verify backwards compatibility for relative paths with leading '/' """
+        st = default_wbank.get_waveforms()
+        assert len(st)
 
 
 class TestEmptyBank:

--- a/tests/test_stations/test_pd_stations.py
+++ b/tests/test_stations/test_pd_stations.py
@@ -75,7 +75,6 @@ class TestInv2Df:
             invdf.loc[invdf["station"] == "RJOB", "location"] = input
         else:
             invdf.loc[invdf["station"] == "RJOB", "location"] = input
-        # breakpoint()
         invdf = stations_to_df(invdf)
         rjob = invdf.loc[invdf["station"] == "RJOB"]
         not_rjob = invdf.loc[invdf["station"] != "RJOB"]

--- a/tests/test_stations/test_pd_stations.py
+++ b/tests/test_stations/test_pd_stations.py
@@ -298,7 +298,7 @@ class TestReadDataFrame:
     @pytest.fixture
     def df_bad_location(self, inv_df):
         """make location codes nan, run through read_inventory"""
-        inv_df.loc[:, "location"] = np.NaN
+        inv_df["location"] = np.NaN
         return stations_to_df(inv_df)
 
     # tests

--- a/tests/test_utils/test_stations_utils.py
+++ b/tests/test_utils/test_stations_utils.py
@@ -196,8 +196,8 @@ class TestDfToInventory:
         df_from_inv["bob"] = 1
         with pytest.warns(UserWarning) as w:
             df_to_inventory(df_from_inv)
-        assert len(w) == 1
-        assert "found unexpected columns" in w.list[0].message.args[0]
+        messages = " ".join([x.message.args[0] for x in w.list])
+        assert "found unexpected columns" in messages
 
 
 @pytest.mark.requires_network

--- a/tests/test_utils/test_waveforms_utils.py
+++ b/tests/test_utils/test_waveforms_utils.py
@@ -376,7 +376,7 @@ class TestArchiveToSDS:
         """ensure each file in the sds has exactly one channel"""
         index = sds_wavebank.read_index()
         for fi in index.path.unique():
-            base = Path(sds_wavebank.bank_path) / fi[1:]
+            base = sds_wavebank.bank_path / fi
             st = obspy.read(str(base))
             assert len({tr.id for tr in st}) == 1
 


### PR DESCRIPTION
This addresses Issue #255 by removing the leading '/' from the relative file paths for any new entries in bank indices. Per an offline conversation with @d-chambers, this also attempts to maintain backwards compatibility with existing bank indices. It worked for my test case, but it might be good for someone else to also check it with an existing bank.

If people do encounter weird issues, deleting and re-creating the index should solve the problem.