### PR TITLE
Added an optional 'detailed' flag to get_uptime_df

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup conda
         uses: s-weigand/setup-conda@v1
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - name: install linting packages
         run: pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.10.0
     hooks:
     -   id: black
         language_version: python3
@@ -16,7 +16,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==21.5b1]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 6.0.0
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==21.5b1]
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 5.0.4
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.8.3
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 master
   - obsplus.bank.wavebank
-    * Added an optional 'detailed' flag to get_uptime_df to return each segment
-      of contiguous data rather than just stats for each seed id.
+    * Added a method called "get_segments_df" to return each segment of
+      contiguous data.
 
 obsplus 0.2.3
   - obsplus.bank

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 master
   - obsplus.bank.wavebank
-    * Added an optional 'detailed' flag to get_uptime_df to return each segment 
+    * Added an optional 'detailed' flag to get_uptime_df to return each segment
       of contiguous data rather than just stats for each seed id.
 
 obsplus 0.2.3

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+master
+  - obsplus.bank.wavebank
+    * Added an optional 'detailed' flag to get_uptime_df to return each segment 
+      of contiguous data rather than just stats for each seed id.
+
 obsplus 0.2.3
   - obsplus.bank
     * Better support for bank paths on Windows See # 256.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,7 @@ obsplus 0.2.0
   - obsplus.structures.fetcher
     * fixed an edge case were banks with only one file failed to return
        streams (#186).
-  - obsplus.structures.dxfextractor
+  - obsplus.structures.dfextractor
     * Handled the case of null integers in the NSLC columns and added a logic
       to force the seed_id column to match the other NSLC columns(#199)
   - obsplus.utils

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -158,6 +158,9 @@ class WaveBank(_Bank):
     index_columns = tuple(list(index_str) + list(index_ints) + ["path"])
     columns_no_path = index_columns[:-1]
     _gap_columns = tuple(list(columns_no_path) + ["gap_duration"])
+    _detailed_uptime_columns = tuple(
+        list(index_str) + ["starttime", "endtime", "duration"]
+    )
     namespace = "/waveforms"
     buffer = np.timedelta64(1_000_000_000, "ns")
     # dict defining lengths of str columns (after seed spec)
@@ -439,7 +442,9 @@ class WaveBank(_Bank):
                 .reset_index(drop=True)
             )
             shifted_starttimes = dd.starttime.shift(-1)
-            cum_max = np.maximum.accumulate(dd["endtime"] + min_gap)
+            cum_max = np.maximum.accumulate(
+                dd["endtime"] + min_gap
+            )  # Handles data overlaps
             gap_index = cum_max < shifted_starttimes
             # create a dataframe of gaps
             df = dd[gap_index]
@@ -458,32 +463,88 @@ class WaveBank(_Bank):
         return out.reset_index(drop=True)
 
     @compose_docstring(get_waveforms_params=get_waveforms_parameters)
-    def get_uptime_df(self, *args, **kwargs) -> pd.DataFrame:
+    def get_uptime_df(
+        self,
+        *args,
+        detailed: bool = False,
+        min_gap: Optional[Union[float, np.timedelta64]] = None,
+        **kwargs,
+    ) -> pd.DataFrame:
         """
         Return a dataframe with uptime stats for selected channels.
 
         Parameters
         ----------
         {get_waveforms_params}
-
+        detailed
+            If True, return a detailed listing of every continuous segment of
+            data for the selected channels
         """
-        # get total number of seconds bank spans for each seed id
+
+        def _summary_report():
+            # get total number of seconds bank spans for each seed id
+            avail["duration"] = avail["endtime"] - avail["starttime"]
+            # get total duration of gaps by seed id
+            if gaps_df.empty:
+                gap_total_df = pd.DataFrame(avail[list(NSLC)])
+                gap_total_df["gap_duration"] = EMPTYTD64
+            else:
+                gap_totals = gaps_df.groupby(list(NSLC)).gap_duration.sum()
+                gap_total_df = pd.DataFrame(gap_totals).reset_index()
+            # merge gap dataframe with availability dataframe, add uptime and %
+            df = pd.merge(avail, gap_total_df, how="outer")
+            # fill any Nan in gap_duration with empty timedelta
+            df["gap_duration"] = df["gap_duration"].fillna(EMPTYTD64)
+            df["uptime"] = df["duration"] - df["gap_duration"]
+            df["availability"] = df["uptime"] / df["duration"]
+            return df
+
+        def _detailed_report():
+            def _get_details(ser):
+                # Get the gap report for the seed id
+                seed_id = tuple(ser[list(NSLC)].values)
+                if seed_id in gps.groups:
+                    df = gps.get_group(seed_id).reset_index(drop=True)
+                    df.loc[max(df.index) + 1, :] = None
+                    starttime = df["endtime"].shift(
+                        1
+                    )  # End of the gap is the start of the next data segment
+                    starttime.name = "starttime"
+                    endtime = df[
+                        "starttime"
+                    ]  # Start of the gap is end of the data segment
+                    endtime.name = "endtime"
+                    # Fill in the missing values
+                    starttime[0] = ser.starttime
+                    endtime[max(endtime.index)] = ser.endtime
+                    # Build the dataframe
+                    uptime = pd.concat([starttime, endtime], axis=1)
+                else:
+                    df = pd.DataFrame(columns=gaps_df.columns)
+                    uptime = pd.DataFrame(
+                        [[ser["starttime"], ser["endtime"]]],
+                        columns=["starttime", "endtime"],
+                    )
+                uptime["duration"] = uptime["endtime"] - uptime["starttime"]
+                for x in NSLC:
+                    uptime[x] = ser[x]
+                return uptime
+
+            gps = gaps_df.groupby(list(NSLC))
+            if not len(avail):
+                return pd.DataFrame(columns=self._detailed_uptime_columns)
+            return pd.concat(
+                [_get_details(row) for _, row in avail.iterrows()]
+            ).reset_index()
+
         avail = self.get_availability_df(*args, **kwargs)
-        avail["duration"] = avail["endtime"] - avail["starttime"]
-        # get total duration of gaps by seed id
         gaps_df = self.get_gaps_df(*args, **kwargs)
-        if gaps_df.empty:
-            gap_total_df = pd.DataFrame(avail[list(NSLC)])
-            gap_total_df["gap_duration"] = EMPTYTD64
+
+        if detailed:
+            df = _detailed_report()
         else:
-            gap_totals = gaps_df.groupby(list(NSLC)).gap_duration.sum()
-            gap_total_df = pd.DataFrame(gap_totals).reset_index()
-        # merge gap dataframe with availability dataframe, add uptime and %
-        df = pd.merge(avail, gap_total_df, how="outer")
-        # fill any Nan in gap_duration with empty timedelta
-        df["gap_duration"] = df["gap_duration"].fillna(EMPTYTD64)
-        df["uptime"] = df["duration"] - df["gap_duration"]
-        df["availability"] = df["uptime"] / df["duration"]
+            df = _summary_report()
+
         return df
 
     # ------------------------ get waveform related methods

--- a/obsplus/bank/wavebank.py
+++ b/obsplus/bank/wavebank.py
@@ -535,7 +535,7 @@ class WaveBank(_Bank):
                 return pd.DataFrame(columns=self._detailed_uptime_columns)
             return pd.concat(
                 [_get_details(row) for _, row in avail.iterrows()]
-            ).reset_index()
+            ).reset_index(drop=True)
 
         avail = self.get_availability_df(*args, **kwargs)
         gaps_df = self.get_gaps_df(*args, **kwargs)

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -115,7 +115,7 @@ class _OriginQualityExtractor:
             ("used_phase_count", out.get("used_phase_count", 0)),
         )
         quality = getattr(origin, "quality", ev.OriginQuality())
-        for (attr, default) in quality_attrs:
+        for attr, default in quality_attrs:
             out[attr] = getattr(quality, attr, None) or default
 
     def _get_origin_uncertainty(self, origin, out):

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -569,7 +569,7 @@ def _get_seed_id(obj):
 
 # --- monkey patch events/event classes to have to_df methods.
 
-# event_to_dataframe
+
 def event_to_dataframe(cat_or_event):
     """
     Given a catalog or event, return a DataFrame summary.

--- a/obsplus/events/pd.py
+++ b/obsplus/events/pd.py
@@ -122,7 +122,7 @@ class _OriginQualityExtractor:
         """Get information from uncertainty."""
         uncert_attrs = (("horizontal_uncertainty", np.NaN),)
         uncert = getattr(origin, "origin_uncertainty", ev.OriginUncertainty())
-        for (attr, default) in uncert_attrs:
+        for attr, default in uncert_attrs:
             out[attr] = getattr(uncert, attr, default) or default
 
     def _get_depth_uncertainty_info(self, origin, out):

--- a/obsplus/utils/docs.py
+++ b/obsplus/utils/docs.py
@@ -33,7 +33,6 @@ def compose_docstring(**kwargs: Union[str, Sequence[str]]):
     """
 
     def _wrap(func):
-
         docstring = func.__doc__
         # iterate each provided value and look for it in the docstring
         for key, value in kwargs.items():

--- a/obsplus/utils/testing.py
+++ b/obsplus/utils/testing.py
@@ -160,7 +160,7 @@ class ArchiveDirectory:
         # ensure directory exists
         path = Path(self.path)
         path.mkdir(exist_ok=True, parents=True)
-        for (net, sta, loc, chan, t1, t2) in bulk_args:
+        for net, sta, loc, chan, t1, t2 in bulk_args:
             nslc = ".".join([net, sta, loc, chan])
             st = self.create_stream(t1, t2, (nslc,))
             time_name = str(t1).split(".")[0].replace(":", "-") + ".mseed"

--- a/obsplus/waveforms/get_waveforms.py
+++ b/obsplus/waveforms/get_waveforms.py
@@ -78,7 +78,7 @@ def get_waveforms_bulk(
     # get unique times and check conditions for string columns
     unique_times = np.unique(request_df[["starttime", "endtime"]].values, axis=0)
     traces = []
-    for (t1, t2) in unique_times:
+    for t1, t2 in unique_times:
         sub = _filter_index_to_bulk((t1, t2), index_df=index, bulk_df=request_df)
         new = obspy.Stream(traces=[x.data for x in sub["trace"]]).slice(
             starttime=to_utc(t1), endtime=to_utc(t2)


### PR DESCRIPTION
This PR adds an optional 'detailed' argument to WaveBank's get_uptime_df method.

By default, this method just returns one row per NSLC that provides stats about the amount of data, number of gaps, length of gaps, etc. There's additionally the get_gaps_df method that returns a list of each gap in the data in the bank. This change fills a hole where I wanted a listing of each contiguous segment of data in the bank.

The default behavior of the method is not affected.