### PR TITLE
Fix bug where passing 'min_gap' to  raises an exception

### DIFF
--- a/src/obsplus/bank/wavebank.py
+++ b/src/obsplus/bank/wavebank.py
@@ -541,8 +541,10 @@ class WaveBank(_Bank):
                 uptime[x] = ser[x]
             return uptime
 
+        min_gap = kwargs.pop("min_gap", None)
+        
         avail = self.get_availability_df(*args, **kwargs)
-        gaps_df = self.get_gaps_df(*args, **kwargs)
+        gaps_df = self.get_gaps_df(*args, min_gap=min_gap, **kwargs)
         gps = gaps_df.groupby(list(NSLC))
         if not len(avail):
             return pd.DataFrame(columns=self._segment_columns)

--- a/tests/test_bank/test_wavebank.py
+++ b/tests/test_bank/test_wavebank.py
@@ -1423,6 +1423,12 @@ class TestGetGaps:
         with_gap = gappy_bank.get_gaps_df()
         assert len(no_gap) < len(with_gap)
 
+    def test_segments_min_gap_param(self, gappy_bank):
+        """Ensure the min gap parameter works for get_segments_df"""
+        wo_min_gap = gappy_bank.get_segments_df()
+        w_min_gap = gappy_bank.get_segments_df(min_gap=10000000)
+        assert len(w_min_gap) < len(wo_min_gap)
+
 
 class TestBadInputs:
     """ensure wavebank handles bad inputs correctly"""


### PR DESCRIPTION
Fixes a small bug in `WaveBank.get_segments_df`.