### PR TITLE
Add ability to pass alternate index_path to `WaveBank` and `EventBank`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,9 @@
 master
+  - obsplus.bank
+    * Tweaked the banks to allow for custom index paths. See #258.
   - obsplus.utils.stations
     * Fixed df_to_inventory to use a local copy of the NRL for compatibility
-      with ObsPy and NRLv2 (Note that NRLv1 is no longer accessible)
+      with ObsPy and NRLv2 (Note that NRLv1 is no longer accessible) (#271)
 
 obsplus 0.2.5
   - obsplus

--- a/docs/notebooks/interfaces/eventbank.ipynb
+++ b/docs/notebooks/interfaces/eventbank.ipynb
@@ -49,7 +49,7 @@
     "bank = obsplus.EventBank(event_path)\n",
     "\n",
     "# ensure index is up-to-date\n",
-    "bank.update_index() "
+    "bank.update_index()"
    ]
   },
   {
@@ -84,6 +84,29 @@
    "outputs": [],
    "source": [
     "print(index.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are working from a data directory that doesn't have write access, you can specify a custom location for the index path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "index_path = Path(tempfile.mkdtemp()) / \"index.db\"\n",
+    "cust_ind_bank = obsplus.EventBank(event_path, index_path=index_path)\n",
+    "cust_ind_bank.update_index()\n",
+    "ind = cust_ind_bank.read_index()\n",
+    "ind  # Note that paths in the index are relative to event_path"
    ]
   },
   {
@@ -213,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/interfaces/wavebank.ipynb
+++ b/docs/notebooks/interfaces/wavebank.ipynb
@@ -86,6 +86,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Using a custom index path\n",
+    "\n",
+    "If you are working from a data directory that doesn't have write access, you can specify a custom location for the index path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "index_path = Path(tempfile.mkdtemp()) / \"index.h5\"\n",
+    "cust_ind_bank = obsplus.WaveBank(crandall_path, index_path=index_path)\n",
+    "cust_ind_bank.update_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Get waveforms\n",
     "\n",
     "The files can be retrieved from the directory with the `get_waveforms` method. This method has the same signature as the ObsPy client `get_waveform` methods so they can be used interchangeably:"
@@ -344,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/src/obsplus/bank/core.py
+++ b/src/obsplus/bank/core.py
@@ -38,7 +38,8 @@ class _Bank(ABC):
     ext = ""
     bank_path: Path = ""
     namespace = ""
-    index_name = ".index.h5"  # name of index file
+    index_name = ".index.h5"  # default name of index file
+    _index_path: Path = None  # Override for the index path
     executor = None  # an executor for using parallelism
     # optional str defining the directory structure and file name schemes
     path_structure = None
@@ -89,7 +90,7 @@ class _Bank(ABC):
     @property
     def index_path(self):
         """Return the expected path to the index file."""
-        return Path(self.bank_path) / self.index_name
+        return self._index_path or Path(self.bank_path) / self.index_name
 
     @property
     def _index_node(self):

--- a/src/obsplus/bank/core.py
+++ b/src/obsplus/bank/core.py
@@ -320,6 +320,6 @@ class _Bank(ABC):
     def __repr__(self):
         """Return the class name with bank path."""
         name = type(self).__name__
-        return f"{name}(base_path={self.bank_path})"
+        return f"{name}(base_path={self.bank_path}, index_path={self.index_path})"
 
     __str__ = __repr__

--- a/src/obsplus/bank/eventbank.py
+++ b/src/obsplus/bank/eventbank.py
@@ -102,6 +102,9 @@ class EventBank(_Bank):
         variables and a slash cannot be used in a file name on most operating
         systems. The default extension (.xml) will be added.
         The default is {time}_{event_id_short}.
+    index_path
+        The path to the index file containing the contents of the directory.
+        By default it will be created in the top-level of the data directory.
     format
         The anticipated format of the event files. Any format supported by the
         obspy.read_events function is permitted.
@@ -160,6 +163,7 @@ class EventBank(_Bank):
         base_path: Union[str, Path, "EventBank"] = ".",
         path_structure: Optional[str] = None,
         name_structure: Optional[str] = None,
+        index_path: Optional[Union[str, Path]] = None,
         format="quakeml",
         ext=".xml",
         executor: Optional[Executor] = None,
@@ -181,6 +185,7 @@ class EventBank(_Bank):
         self.path_structure = ps
         ns = name_structure or self._name_structure or EVENT_NAME_STRUCTURE
         self.name_structure = ns
+        self._index_path = index_path
         self.executor = executor
         # enforce min version and warn on newer
         self._enforce_min_version()

--- a/src/obsplus/bank/wavebank.py
+++ b/src/obsplus/bank/wavebank.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import obspy
@@ -90,6 +90,9 @@ class WaveBank(_Bank):
         variables but requires a period as the separation character. The
         default extension (.mseed) will be added. The default is {time}
         example : {seedid}.{time}
+    index_path : str
+        The path to the index file containing the contents of the directory.
+        By default it will be created in the top-level of the data directory.
     cache_size : int
         The number of queries to store. Avoids having to read the index of
         the bank multiple times for queries involving the same start and end
@@ -175,6 +178,7 @@ class WaveBank(_Bank):
         base_path: Union[str, Path, "WaveBank"] = ".",
         path_structure: Optional[str] = None,
         name_structure: Optional[str] = None,
+        index_path: Optional[Union[str, Path]] = None,
         cache_size: int = 5,
         format="mseed",
         ext=None,
@@ -191,6 +195,7 @@ class WaveBank(_Bank):
             path_structure if path_structure is not None else WAVEFORM_STRUCTURE
         )
         self.name_structure = name_structure or WAVEFORM_NAME_STRUCTURE
+        self._index_path = index_path
         self.executor = executor
         # initialize cache
         self._index_cache = _IndexCache(self, cache_size=cache_size)
@@ -227,7 +232,7 @@ class WaveBank(_Bank):
         bar_description=bar_parameter_description, paths_description=paths_description
     )
     def update_index(
-        self, bar: Optional = None, paths: Optional[bank_subpaths_type] = None
+        self, bar: Optional[Any] = None, paths: Optional[bank_subpaths_type] = None
     ) -> "WaveBank":
         """
         Iterate files in bank and add any modified since last update to index.

--- a/src/obsplus/utils/testing.py
+++ b/src/obsplus/utils/testing.py
@@ -12,7 +12,10 @@ import numpy as np
 import obspy
 import pandas as pd
 
+from obsplus.bank.core import _Bank
 from obsplus.constants import NSLC, utc_able_type
+from obsplus.utils.bank import _natify_paths
+from obsplus.utils.misc import iter_files
 from obsplus.utils.time import make_time_chunks, to_utc
 
 
@@ -302,3 +305,22 @@ class _StreamEqualTester:
         for tr1, tr2 in zip(st1, st2):
             self._assert_stats_equal(tr1, tr2)
             self._assert_arrays_almost_equal(tr1, tr2)
+
+
+def check_index_paths(bank: _Bank):
+    """
+    Make sure the paths in a bank's index can be resolved correctly
+
+    Parameters
+    ----------
+    bank:
+        A Bank (either WaveBank or EventBank) to verify
+    """
+    bank_path = bank.bank_path
+    index = bank.read_index()
+    index_paths = _natify_paths(index["path"])
+    file_paths = set([bank.bank_path / pth for pth in index_paths])
+    for file_path in iter_files(str(bank_path), ext="mseed"):
+        # go up two levels to match path reference
+        file_path = Path(file_path)
+        assert file_path in file_paths


### PR DESCRIPTION
This addresses #258 by adding an index_path kwarg to `WaveBank` and `EventBank` (similar to https://github.com/DASDAE/dascore/pull/131).