### PR TITLE
remove tkinter progress bar annotation

### DIFF
--- a/src/obsplus/utils/misc.py
+++ b/src/obsplus/utils/misc.py
@@ -13,7 +13,6 @@ from collections.abc import Callable, Collection, Generator, Iterable
 from functools import partial, singledispatch, wraps
 from os.path import join
 from pathlib import Path, PurePosixPath
-from tkinter.ttk import Progressbar
 from typing import (
     Any,
     TypeVar,
@@ -26,20 +25,13 @@ from obspy.core import event as ev
 from obspy.core.inventory import Channel, Station
 from obspy.io.mseed.core import _read_mseed as mread
 from obspy.io.quakeml.core import _read_quakeml
+from progressbar import ProgressBar
 
 import obsplus
 from obsplus.constants import NSLC, NULL_SEED_CODES
 
 BASIC_NON_SEQUENCE_TYPE = (int, float, str, bool, type(None))
 READ_DICT = dict(mseed=mread, quakeml=_read_quakeml)
-
-
-def _get_progressbar():
-    """Suppress ProgressBar's warning."""
-    # TODO remove this when progress no longer issues warning
-    with suppress_warnings():
-        from progressbar import ProgressBar
-    return ProgressBar
 
 
 def deprecated_callable(func=None, replacement_str=None):
@@ -232,7 +224,7 @@ def apply_to_files_or_skip(func: Callable, directory: str | Path):
                 pass
 
 
-def get_progressbar(max_value, min_value=None, *args, **kwargs) -> Progressbar | None:
+def get_progressbar(max_value, min_value=None, *args, **kwargs) -> ProgressBar | None:
     """
     Get a progress bar object using the ProgressBar2 library.
 
@@ -260,8 +252,7 @@ def get_progressbar(max_value, min_value=None, *args, **kwargs) -> Progressbar |
     if min_value and max_value < min_value:
         return None  # no progress bar needed, return None
     try:
-        progress_bar = _get_progressbar()
-        bar = progress_bar(max_value=max_value, *args, **kwargs)
+        bar = ProgressBar(max_value=max_value, *args, **kwargs)
         bar.start()
         bar.update = _new_update(bar)
         bar.update(1)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -8,7 +8,7 @@ import obspy
 import pytest
 from obsplus import EventBank, WaveBank
 from obsplus.interfaces import EventClient, ProgressBar, StationClient, WaveformClient
-from obsplus.utils.misc import _get_progressbar
+from obsplus.utils.misc import ProgressBar as BaseProgressBar
 from obspy.clients.fdsn.client import Client, FDSNException
 
 # fixtures
@@ -106,8 +106,7 @@ class TestBar:
 
     def test_progressbar_isinstance(self):
         """Ensure the ProgressBar2 ProgressBar is an instance."""
-        progbar = _get_progressbar()
-        assert issubclass(progbar, ProgressBar)
+        assert issubclass(BaseProgressBar, ProgressBar)
 
     def test_custom_progress_bar(self):
         """Ensure custom progress bar works as well."""

--- a/tests/test_utils/test_misc_utils.py
+++ b/tests/test_utils/test_misc_utils.py
@@ -260,7 +260,7 @@ class TestProgressBar:
 
     def test_graceful_progress_fail(self, monkeypatch):
         """Ensure a progress bar that cant update returns None"""
-        progress_bar = obsplus.utils.misc._get_progressbar()
+        progress_bar = obsplus.utils.misc.ProgressBar
 
         def raise_exception():
             raise Exception
@@ -270,7 +270,7 @@ class TestProgressBar:
 
     def test_simple_progress_bar(self):
         """Ensure a simple progress bar can be used."""
-        progress_bar = obsplus.utils.misc._get_progressbar()
+        progress_bar = obsplus.utils.misc.ProgressBar
 
         bar = obsplus.utils.misc.get_progressbar(max_value=100, min_value=1)
         assert isinstance(bar, progress_bar)


### PR DESCRIPTION
This PR fixes a minor type annotation error in which the TKinter, rather than progressbar package, `ProgressBar` class was used as a type annotation for `obsplus.utils.misc.get_progressbar`. This caused issues on slim python builds that don't include tkinter (eg installed with uv).

