### PR TITLE
test python 3.13

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', "3.13"]
 
 
     # only run if CI isn't turned off

--- a/src/obsplus/utils/docs.py
+++ b/src/obsplus/utils/docs.py
@@ -25,6 +25,9 @@ def compose_docstring(**kwargs: str | Sequence[str]):
 
     Examples
     --------
+    ```{python}
+    from dascore.utils.docs import compose_docstring
+
     @compose_docstring(some_value='10')
     def example_function():
         '''
@@ -33,15 +36,17 @@ def compose_docstring(**kwargs: str | Sequence[str]):
         The following line will be the string '10':
         {some_value}
         '''
+    ```
     """
 
     def _wrap(func):
         docstring = func.__doc__
+        assert isinstance(docstring, str)
         # iterate each provided value and look for it in the docstring
         for key, value in kwargs.items():
             value = value if isinstance(value, str) else "\n".join(value)
             # strip out first line if needed
-            value = value.lstrip()
+            value = textwrap.dedent(value).lstrip()
             search_value = f"{{{key}}}"
             # find all lines that match values
             lines = [x for x in docstring.split("\n") if search_value in x]
@@ -49,7 +54,7 @@ def compose_docstring(**kwargs: str | Sequence[str]):
                 # determine number of spaces used before matching character
                 spaces = line.split(search_value)[0]
                 # ensure only spaces precede search value
-                assert set(spaces) == {" "}
+                assert set(spaces) == {" "} or not len(spaces)
                 new = textwrap.indent(textwrap.dedent(value), spaces)
                 docstring = docstring.replace(line, new)
 

--- a/tests/test_utils/test_doc_utils.py
+++ b/tests/test_utils/test_doc_utils.py
@@ -6,7 +6,7 @@ from obsplus.constants import STATION_DTYPES
 from obsplus.utils.docs import compose_docstring, format_dtypes
 
 
-class TestDocsting:
+class TestDocstring:
     """tests for obsplus' simple docstring substitution function."""
 
     def count_white_space(self, some_str):
@@ -19,9 +19,9 @@ class TestDocsting:
             """
         Parameters
         ----------
-        a: int
+        a
             a
-        b int
+        b
             b
         """
         )
@@ -29,13 +29,17 @@ class TestDocsting:
         @compose_docstring(params=params)
         def testfun1():
             """
+            A simple test function.
+
             {params}
             """
 
         assert "Parameters" in testfun1.__doc__
         line = next(x for x in testfun1.__doc__.split("\n") if "Parameters" in x)
         base_spaces = line.split("Parameters")[0]
-        assert len(base_spaces) == 12
+        # py3.13+ automatically strips white space from docstrings so 12
+        # and 0 are valid lengths.
+        assert len(base_spaces) in {12, 0}
 
     def test_list_indent(self):
         """Ensure lists are indented equally."""


### PR DESCRIPTION
This PR adds support for python 3.13 (better late than never). 

It also fixes a bug with `obsplus.utils.docs.compose_docstring` that accounts for how python 3.13 handles spaces in docstrings. It supersedes #283  which was based on the wrong branch. 